### PR TITLE
Commit related to issue #61 - Allowing reset fields except in default mandatory ones

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
@@ -32,6 +32,7 @@ public class Issue implements Identifiable {
     private String statusName;
     private Version targetVersion;
     private IssueCategory category;
+    private Boolean resettable = Boolean.FALSE;
 
     /**
      * Some comment describing the issue update
@@ -289,6 +290,7 @@ public class Issue implements Identifiable {
                 + ((updatedOn == null) ? 0 : updatedOn.hashCode());
         result = prime * result
             + ((changesets == null) ? 0 : changesets.hashCode());
+        result = prime * result + ((resettable == null) ? 0 : resettable.hashCode());
         return result;
     }
 
@@ -479,6 +481,13 @@ public class Issue implements Identifiable {
         } else if (!changesets.equals(other.changesets)) {
             return false;
         }
+        if (resettable == null) {
+            if (other.resettable != null) {
+                return false;
+            }
+        } else if (!resettable.equals(other.resettable)) {
+            return false;
+        }
         return true;
     }
 
@@ -537,5 +546,13 @@ public class Issue implements Identifiable {
 
     public void setCategory(IssueCategory category) {
         this.category = category;
+    }
+    
+    public Boolean getResettable() {
+        return resettable;
+    }
+
+    public void setResettable(Boolean resettable) {
+        this.resettable = resettable;
     }
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -276,59 +276,98 @@ public class RedmineJSONBuilder {
 		JsonOutput.addIfNotNull(writer, "login", group.getName());
 	}
 
-	public static void writeIssue(Issue issue, final JSONWriter writer)
-			throws JSONException {
-		JsonOutput.addIfNotNull(writer, "id", issue.getId());
-		JsonOutput.addIfNotNull(writer, "subject", issue.getSubject());
-		JsonOutput.addIfNotNull(writer, "parent_issue_id", issue.getParentId());
-		JsonOutput.addIfNotNull(writer, "estimated_hours",
-				issue.getEstimatedHours());
-		JsonOutput.addIfNotNull(writer, "spent_hours", issue.getSpentHours());
-		if (issue.getAssignee() != null)
-			JsonOutput.addIfNotNull(writer, "assigned_to_id", issue
-					.getAssignee().getId());
-		JsonOutput.addIfNotNull(writer, "priority_id", issue.getPriorityId());
-		JsonOutput.addIfNotNull(writer, "done_ratio", issue.getDoneRatio());
-		if (issue.getProject() != null)
-			JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
-					.getIdentifier());
-		if (issue.getAuthor() != null)
-			JsonOutput.addIfNotNull(writer, "author_id", issue.getAuthor()
-					.getId());
-		addFull(writer, "start_date", issue.getStartDate());
-		addIfNotNullFull(writer, "due_date", issue.getDueDate());
-		if (issue.getTracker() != null)
-			JsonOutput.addIfNotNull(writer, "tracker_id", issue.getTracker()
-					.getId());
-		JsonOutput.addIfNotNull(writer, "description", issue.getDescription());
-
-		addIfNotNullFull(writer, "created_on", issue.getCreatedOn());
-		addIfNotNullFull(writer, "updated_on", issue.getUpdatedOn());
-		JsonOutput.addIfNotNull(writer, "status_id", issue.getStatusId());
-		if (issue.getTargetVersion() != null)
-			JsonOutput.addIfNotNull(writer, "fixed_version_id", issue
-					.getTargetVersion().getId());
-		if (issue.getCategory() != null)
-			JsonOutput.addIfNotNull(writer, "category_id", issue.getCategory()
-					.getId());
-		JsonOutput.addIfNotNull(writer, "notes", issue.getNotes());
-		writeCustomFields(writer, issue.getCustomFields());
-
-		if (issue.getAttachments() != null && issue.getAttachments().size() > 0) {
-			final List<Attachment> uploads = new ArrayList<Attachment>();
-			for (Attachment attach : issue.getAttachments())
-				if (attach.getToken() != null)
-					uploads.add(attach);
-			JsonOutput.addArrayIfNotEmpty(writer, "uploads", uploads,
-					UPLOAD_WRITER);
-		}
-		
-
-		/*
-		 * Journals and Relations cannot be set for an issue during creation or
-		 * updates.
-		 */
-	}
+	/**
+     * Add values from issue into writer. 
+     * Allowing reset values depending on resettable issue field.
+     * @param issue
+     * @param writer
+     * @throws JSONException
+     */
+    public static void writeIssue(Issue issue, final JSONWriter writer)
+            throws JSONException {
+        JsonOutput.addIfNotNull(writer, "id", issue.getId());
+        JsonOutput.addIfNotNull(writer, "subject", issue.getSubject());
+        JsonOutput.addIfNotNull(writer, "priority_id", issue.getPriorityId());
+        if (issue.getProject() != null)
+            JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
+                    .getIdentifier());
+        if (issue.getTracker() != null)
+            JsonOutput.addIfNotNull(writer, "tracker_id", issue.getTracker()
+                    .getId());
+        if (issue.getAttachments() != null && issue.getAttachments().size() > 0) {
+            final List<Attachment> uploads = new ArrayList<Attachment>();
+            for (Attachment attach : issue.getAttachments())
+                if (attach.getToken() != null)
+                    uploads.add(attach);
+            JsonOutput.addArrayIfNotEmpty(writer, "uploads", uploads,
+                    UPLOAD_WRITER);
+        }
+        writeCustomFields(writer, issue.getCustomFields());
+        
+        if (issue.getResettable()){
+            writeIssueResettable(issue, writer);
+        }else{
+            writeIssueNotResettable(issue, writer);
+        }
+        
+        /*
+         * Journals and Relations cannot be set for an issue during creation or
+         * updates.
+         */
+    }
+    
+    private static void writeIssueNotResettable(Issue issue, final JSONWriter writer)
+            throws JSONException {
+        JsonOutput.addIfNotNull(writer, "parent_issue_id", issue.getParentId());
+        JsonOutput.addIfNotNull(writer, "estimated_hours", issue.getEstimatedHours());
+        JsonOutput.addIfNotNull(writer, "spent_hours", issue.getSpentHours());
+        if (issue.getAssignee() != null)
+            JsonOutput.addIfNotNull(writer, "assigned_to_id", issue
+                    .getAssignee().getId());
+        JsonOutput.addIfNotNull(writer, "done_ratio", issue.getDoneRatio());
+        if (issue.getAuthor() != null)
+            JsonOutput.addIfNotNull(writer, "author_id", issue.getAuthor()
+                    .getId());
+        JsonOutput.addIfNotNull(writer, "description", issue.getDescription());
+        JsonOutput.addIfNotNull(writer, "status_id", issue.getStatusId());
+        if (issue.getTargetVersion() != null)
+            JsonOutput.addIfNotNull(writer, "fixed_version_id", issue
+                    .getTargetVersion().getId());
+        if (issue.getCategory() != null)
+            JsonOutput.addIfNotNull(writer, "category_id", issue.getCategory()
+                    .getId());
+        JsonOutput.addIfNotNull(writer, "notes", issue.getNotes());
+        addIfNotNullFull(writer, "start_date", issue.getStartDate());
+        addIfNotNullFull(writer, "due_date", issue.getDueDate());
+        addIfNotNullFull(writer, "created_on", issue.getCreatedOn());
+        addIfNotNullFull(writer, "updated_on", issue.getUpdatedOn());
+    }
+    
+    public static void writeIssueResettable(Issue issue, final JSONWriter writer)
+            throws JSONException {
+        
+        JsonOutput.add(writer, "parent_issue_id", issue.getParentId());
+        JsonOutput.add(writer, "estimated_hours", issue.getEstimatedHours());
+        JsonOutput.add(writer, "spent_hours", issue.getSpentHours());
+        JsonOutput.add(writer, "assigned_to_id", issue.getAssignee() == null ? null : 
+                    issue.getAssignee().getId());
+        JsonOutput.add(writer, "done_ratio", issue.getDoneRatio());
+        JsonOutput.add(writer, "author_id", issue.getAuthor() == null ? null :
+                    issue.getAuthor().getId());
+        JsonOutput.add(writer, "description", issue.getDescription());
+        JsonOutput.add(writer, "status_id", issue.getStatusId());
+        JsonOutput.add(writer, "fixed_version_id", issue
+                .getTargetVersion() == null ? null : issue
+                    .getTargetVersion().getId());
+        JsonOutput.add(writer, "category_id", issue
+                .getCategory() == null ? null : issue
+                        .getCategory().getId());
+        JsonOutput.add(writer, "notes", issue.getNotes());
+        addFull(writer, "start_date", issue.getStartDate());
+        addFull(writer, "due_date", issue.getDueDate());
+        addFull(writer, "created_on", issue.getCreatedOn());
+        addFull(writer, "updated_on", issue.getUpdatedOn());
+    }
 
 	public static void writeUpload(JSONWriter writer, Attachment attachment)
 			throws JSONException {

--- a/src/main/java/com/taskadapter/redmineapi/internal/json/JsonOutput.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/json/JsonOutput.java
@@ -191,5 +191,62 @@ public class JsonOutput {
 		}
 		writer.endArray();
 	}
+	
+    /**
+     * Adds a value to a writer. If value is <code>null</code> add null value.
+     * 
+     * @param writer
+     *            writer to add object to.
+     * @param field
+     *            field name to set.
+     * @param value
+     *            field value.
+     * @throws JSONException
+     *             if io error occurs.
+     */
+    public static void add(final JSONWriter writer, final String field,
+            String value) throws JSONException {
+        addEvenNull(writer, field, value);
+    }
+    
+    /**
+     * Adds a value to a writer. If value is <code>null</code> add null value.
+     * 
+     * @param writer
+     *            writer to add object to.
+     * @param field
+     *            field name to set.
+     * @param value
+     *            field value.
+     * @throws JSONException
+     *             if io error occurs.
+     */
+    public static void add(final JSONWriter writer, final String field,
+            Integer value) throws JSONException {
+        addEvenNull(writer, field, value);
+    }
+    
+    /**
+     * Adds a value to a writer. If value is <code>null</code> add null value.
+     * 
+     * @param writer
+     *            writer to add object to.
+     * @param field
+     *            field name to set.
+     * @param value
+     *            field value.
+     * @throws JSONException
+     *             if io error occurs.
+     */
+    public static void add(final JSONWriter writer, final String field,
+            Float value) throws JSONException {
+        addEvenNull(writer, field, value);
+    }
+    
+    private static void addEvenNull(final JSONWriter writer, final String field,
+            Object value) throws JSONException {
+        writer.key(field);
+        writer.value(value);
+    }
 
 }

--- a/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONGeneratorTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONGeneratorTest.java
@@ -17,7 +17,25 @@ public class RedmineJSONGeneratorTest {
 		issue.setPriorityId(1);
 		final String generatedJSON = RedmineJSONBuilder.toSimpleJSON(
                 "some_project_key", issue, RedmineJSONBuilder.ISSUE_WRITER);
-		assertTrue(generatedJSON.contains("\"priority_id\":1,"));
+		assertTrue(generatedJSON.contains("\"priority_id\":1"));
 	}
+	
+	/**
+	 * Covering this bug 
+	 * https://github.com/taskadapter/redmine-java-api/issues/61
+	 */
+	@Test
+    public void nonMandatoryFieldsAreResetIfResettable() {
+        Issue issue = new Issue();
+        issue.setParentId(null);
+        issue.setEstimatedHours(null);
+        issue.setDescription(null);
+        issue.setResettable(Boolean.TRUE);
+        final String generatedJSON = RedmineJSONBuilder.toSimpleJSON(
+                "some_project_key", issue, RedmineJSONBuilder.ISSUE_WRITER);
+        assertTrue(generatedJSON.contains("\"parent_issue_id\":null"));
+        assertTrue(generatedJSON.contains("\"estimated_hours\":null"));
+        assertTrue(generatedJSON.contains("\"description\":null"));
+    }
 
 }


### PR DESCRIPTION
This pull request assures backward compatibility is not broken. The way I choose to implement it maybe is not so straightforward but I didn't want to change so much the architecture code. I've added a new method in RedmineManager called resetIssue for the goal of this issue meanwhile update method will do the same as before.

Well, not exactly the same as I found that the code was allowing reset start_date. I've assumed that is a bug so I've changed it. That's why I had to update priorityIdIsAddedToXMLIfProvided test.
