### PR TITLE
Fixed basic authentication

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/comm/redmine/RedmineAuthenticator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/comm/redmine/RedmineAuthenticator.java
@@ -36,11 +36,9 @@ public class RedmineAuthenticator<K> implements Communicator<K> {
 			return;
 		}
 		try {
-			authKey = "Basic: "
-					+ "\""
+			authKey = "Basic "
 					+ Base64.encodeBase64String(
-							(login + ':' + password).getBytes(charset)).trim()
-					+ "\"";
+							(login + ':' + password).getBytes(charset)).trim();
 		} catch (UnsupportedEncodingException e) {
 			throw new RedmineInternalError(e);
 		}


### PR DESCRIPTION
The header generated by the basic authentication feature was broken (extra colon and unnecessary quotes). I fixed it and tested it with a live redmine server behind HTTPS and Basic authentication.
