### PR TITLE
Issue 125. changed Custom Fields to be a Set instead of List

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     testCompile(
             'junit:junit:4.10',
+            'org.easytesting:fest-assert:1.4',
             'org.slf4j:slf4j-jdk14:1.7.1'
     )
 }

--- a/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
@@ -1,8 +1,13 @@
 package com.taskadapter.redmineapi.bean;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Redmine's Issue
@@ -35,12 +40,17 @@ public class Issue implements Identifiable {
      * Some comment describing the issue update
      */
     private String notes;
-    private List<CustomField> customFields = new ArrayList<CustomField>();
-    private List<Journal> journals = new ArrayList<Journal>();
-    private List<IssueRelation> relations = new ArrayList<IssueRelation>();
-    private List<Attachment> attachments = new ArrayList<Attachment>();
-    private List<Changeset> changesets = new ArrayList<Changeset>();
-    private List<Watcher> watchers = new ArrayList<Watcher>();
+
+    /**
+     * can't have two custom fields with the same ID in the collection, that's why it is declared
+     * as a Set, not a List.
+     */
+    private Set<CustomField> customFields = new HashSet<CustomField>();
+    private Set<Journal> journals = new HashSet<Journal>();
+    private Set<IssueRelation> relations = new HashSet<IssueRelation>();
+    private Set<Attachment> attachments = new HashSet<Attachment>();
+    private Set<Changeset> changesets = new HashSet<Changeset>();
+    private Set<Watcher> watchers = new HashSet<Watcher>();
 
     public Project getProject() {
         return project;
@@ -203,17 +213,31 @@ public class Issue implements Identifiable {
     }
 
     /**
-     * list of Custom Field objects, NEVER NULL.
+     * @return Custom Field objects. the collection may be empty, but it is never NULL.
      */
-    public List<CustomField> getCustomFields() {
-        return customFields;
+    public Collection<CustomField> getCustomFields() {
+        return Collections.unmodifiableCollection(customFields);
+    }
+
+    public void clearCustomFields() {
+        customFields.clear();
     }
 
     /**
      * NOTE: The custom field(s) <b>must have correct database ID set</b> to be saved to Redmine. This is Redmine REST API's limitation.
      */
-    public void setCustomFields(List<CustomField> customFields) {
-        this.customFields = customFields;
+    public void addCustomFields(Collection<CustomField> customFields) {
+        this.customFields.addAll(customFields);
+    }
+
+    /**
+     * If there is a custom field with the same ID already present in the Issue,
+     * the new field replaces the old one.
+     *
+     * @param customField the field to add to the issue.
+     */
+    public void addCustomField(CustomField customField) {
+        customFields.add(customField);
     }
 
     public String getNotes() {
@@ -227,28 +251,28 @@ public class Issue implements Identifiable {
         this.notes = notes;
     }
 
-    public List<Journal> getJournals() {
-        return journals;
+    public Collection<Journal> getJournals() {
+        return Collections.unmodifiableCollection(journals);
     }
 
-    public void setJournals(List<Journal> journals) {
-        this.journals = journals;
+    public void addJournals(Collection<Journal> journals) {
+        this.journals.addAll(journals);
     }
 
-    public List<Changeset> getChangesets() {
-        return changesets;
+    public Collection<Changeset> getChangesets() {
+        return Collections.unmodifiableCollection(changesets);
     }
 
-    public void setChangesets(List<Changeset> changesets) {
-        this.changesets = changesets;
+    public void addChangesets(Collection<Changeset> changesets) {
+        this.changesets.addAll(changesets);
     }
 
-    public List<Watcher> getWatchers() {
-        return watchers;
+    public Collection<Watcher> getWatchers() {
+        return Collections.unmodifiableCollection(watchers);
     }
 
-    public void setWatchers(List<Watcher> watchers) {
-        this.watchers = watchers;
+    public void addWatchers(Collection<Watcher> watchers) {
+        this.watchers.addAll(watchers);
     }
 
     @Override
@@ -298,12 +322,16 @@ public class Issue implements Identifiable {
     /**
      * Relations are only loaded if you include INCLUDE.relations when loading the Issue.
      *
-     * @return list of relations or EMPTY list if no relations, never returns NULL
+     * @return relations or EMPTY collection if no relations, never returns NULL
      *
      * @see com.taskadapter.redmineapi.RedmineManager#getIssueById(Integer id, INCLUDE... include)
      */
-    public List<IssueRelation> getRelations() {
-        return relations;
+    public Collection<IssueRelation> getRelations() {
+        return Collections.unmodifiableCollection(relations);
+    }
+
+    public void addRelations(Collection<IssueRelation> collection) {
+        relations.addAll(collection);
     }
 
     public Integer getPriorityId() {
@@ -318,13 +346,23 @@ public class Issue implements Identifiable {
         return targetVersion;
     }
 
-    public List<Attachment> getAttachments() {
-        return attachments;
+    /**
+     * @return attachments. the collection can be empty, but never null.
+     */
+    public Collection<Attachment> getAttachments() {
+        return Collections.unmodifiableCollection(attachments);
+    }
+
+    public void addAttachments(Collection<Attachment> collection) {
+        attachments.addAll(collection);
+    }
+
+    public void addAttachment(Attachment attachment) {
+        attachments.add(attachment);
     }
 
     public void setTargetVersion(Version version) {
         this.targetVersion = version;
-
     }
 
     public IssueCategory getCategory() {

--- a/src/main/java/com/taskadapter/redmineapi/bean/IssueFactory.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/IssueFactory.java
@@ -1,0 +1,11 @@
+package com.taskadapter.redmineapi.bean;
+
+import com.taskadapter.redmineapi.bean.Issue;
+
+public class IssueFactory {
+    public static Issue create(String subject) {
+        Issue issue = new Issue();
+        issue.setSubject(subject);
+        return issue;
+    }
+}

--- a/src/main/java/com/taskadapter/redmineapi/bean/User.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/User.java
@@ -1,13 +1,15 @@
 package com.taskadapter.redmineapi.bean;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Redmine's User.
- *
- * @author Alexey Skorokhodov
  */
 public class User implements Identifiable {
     private Integer id;
@@ -21,7 +23,7 @@ public class User implements Identifiable {
     private String apiKey;
     private Integer authSourceId;
     // TODO add tests
-    private List<CustomField> customFields = new ArrayList<CustomField>();
+    private Set<CustomField> customFields = new HashSet<CustomField>();
 	private List<Membership> memberships = new ArrayList<Membership>();
 	 private List<Group> groups = new ArrayList<Group>();
 
@@ -177,18 +179,32 @@ public class User implements Identifiable {
     }
 
     /**
-     *  list of Custom Field objects, NEVER NULL.
+     * @return Custom Fields, NEVER NULL.
      */
-    public List<CustomField> getCustomFields() {
-        return customFields;
+    public Collection<CustomField> getCustomFields() {
+        return Collections.unmodifiableCollection(customFields);
+    }
+
+    public void clearCustomFields() {
+        customFields.clear();
     }
 
     /**
      * NOTE: The custom field(s) <b>must have correct database ID set</b> to be saved to Redmine. This is Redmine REST API's limitation.
      * ID can be seen in database or in Redmine administration when editing the custom field (number is part of the URL!).
      */
-    public void setCustomFields(List<CustomField> customFields) {
-        this.customFields = customFields;
+    public void addCustomFields(Collection<CustomField> customFields) {
+        this.customFields.addAll(customFields);
+    }
+
+    /**
+     * If there is a custom field with the same ID already present,
+     * the new field replaces the old one.
+     *
+     * @param customField the field to add.
+     */
+    public void addCustomField(CustomField customField) {
+        customFields.add(customField);
     }
 
 	public List<Membership> getMemberships() {

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -1,11 +1,5 @@
 package com.taskadapter.redmineapi.internal;
 
-import java.io.StringWriter;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import com.taskadapter.redmineapi.RedmineInternalError;
 import com.taskadapter.redmineapi.bean.Attachment;
 import com.taskadapter.redmineapi.bean.CustomField;
@@ -23,9 +17,15 @@ import com.taskadapter.redmineapi.bean.Version;
 import com.taskadapter.redmineapi.bean.Watcher;
 import com.taskadapter.redmineapi.internal.json.JsonObjectWriter;
 import com.taskadapter.redmineapi.internal.json.JsonOutput;
-
-import org.json.JSONWriter;
 import org.json.JSONException;
+import org.json.JSONWriter;
+
+import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Builder for requests to Redmine in JSON format.
@@ -318,20 +318,19 @@ public class RedmineJSONBuilder {
 		JsonOutput.addIfNotNull(writer, "notes", issue.getNotes());
 		writeCustomFields(writer, issue.getCustomFields());
 
-                List<Watcher> issueWatchers = issue.getWatchers();
-                if (issueWatchers != null && !issueWatchers.isEmpty()) {
-                    writeWatchers(writer, issueWatchers);
-                }
-                
-		if (issue.getAttachments() != null && issue.getAttachments().size() > 0) {
-			final List<Attachment> uploads = new ArrayList<Attachment>();
-			for (Attachment attach : issue.getAttachments())
-				if (attach.getToken() != null)
-					uploads.add(attach);
-			JsonOutput.addArrayIfNotEmpty(writer, "uploads", uploads,
-					UPLOAD_WRITER);
-		}
-		
+        Collection<Watcher> issueWatchers = issue.getWatchers();
+        if (issueWatchers != null && !issueWatchers.isEmpty()) {
+            writeWatchers(writer, issueWatchers);
+        }
+        
+        final List<Attachment> uploads = new ArrayList<Attachment>();
+        for (Attachment attachment : issue.getAttachments()) {
+            if (attachment.getToken() != null) {
+                uploads.add(attachment);
+            }
+        }
+        JsonOutput.addArrayIfNotEmpty(writer, "uploads", uploads,
+                UPLOAD_WRITER);
 
 		/*
 		 * Journals and Relations cannot be set for an issue during creation or
@@ -364,9 +363,10 @@ public class RedmineJSONBuilder {
 	}
 
 	private static void writeCustomFields(JSONWriter writer,
-			List<CustomField> customFields) throws JSONException {
-		if (customFields == null || customFields.isEmpty())
-			return;
+			Collection<CustomField> customFields) throws JSONException {
+		if (customFields == null || customFields.isEmpty()) {
+            return;
+        }
 		writer.key("custom_field_values").object();
 		for (CustomField field : customFields) {
             // see https://github.com/taskadapter/redmine-java-api/issues/54
@@ -381,7 +381,7 @@ public class RedmineJSONBuilder {
 		writer.endObject();
 	}
         
-        public static void writeWatchers(JSONWriter writer, List<Watcher> watchers)
+        public static void writeWatchers(JSONWriter writer, Collection<Watcher> watchers)
 			throws JSONException {
             if (watchers == null || watchers.isEmpty()) {
                 return;

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -410,24 +410,21 @@ public class RedmineJSONParser {
 			result.setStatusId(JsonInput.getIntOrNull(statusObject, "id"));
 		}
 
-		result.setCustomFields(JsonInput.getListOrNull(content,
+		result.addCustomFields(JsonInput.getListOrEmpty(content,
 				"custom_fields", CUSTOM_FIELD_PARSER));
 		result.setNotes(JsonInput.getStringOrNull(content, "notes"));
-		result.setJournals(JsonInput.getListOrEmpty(content, "journals",
+		result.addJournals(JsonInput.getListOrEmpty(content, "journals",
 				JOURNAL_PARSER));
-		result.getAttachments().addAll(
+		result.addAttachments(
 				JsonInput.getListOrEmpty(content, "attachments",
 						ATTACHMENT_PARSER));
-		result.getRelations()
-				.addAll(JsonInput.getListOrEmpty(content, "relations",
-						RELATION_PARSER));
-		result.setTargetVersion(JsonInput.getObjectOrNull(content,
-				"fixed_version", VERSION_PARSER));
+		result.addRelations(JsonInput.getListOrEmpty(content, "relations", RELATION_PARSER));
+		result.setTargetVersion(JsonInput.getObjectOrNull(content, "fixed_version", VERSION_PARSER));
 		result.setCategory(JsonInput.getObjectOrNull(content, "category",
 				CATEGORY_PARSER));
-		result.setChangesets(JsonInput.getListOrEmpty(content, "changesets",
+		result.addChangesets(JsonInput.getListOrEmpty(content, "changesets",
 				CHANGESET_PARSER));
-		result.setWatchers(JsonInput.getListOrEmpty(content, "watchers",
+		result.addWatchers(JsonInput.getListOrEmpty(content, "watchers",
 				WATCHER_PARSER));
 		return result;
 	}
@@ -549,7 +546,7 @@ public class RedmineJSONParser {
 		result.setCreatedOn(getDateOrNull(content, "created_on"));
 		result.setLastLoginOn(getDateOrNull(content, "last_login_on"));
                 result.setApiKey(JsonInput.getStringOrNull(content, "api_key"));
-		result.setCustomFields(JsonInput.getListOrEmpty(content,
+		result.addCustomFields(JsonInput.getListOrEmpty(content,
 				"custom_fields", CUSTOM_FIELD_PARSER));
 		final String name = JsonInput.getStringOrNull(content, "name");
 		if (name != null)

--- a/src/test/java/com/taskadapter/redmineapi/AttachmentIntegrationTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/AttachmentIntegrationTest.java
@@ -9,10 +9,12 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
+import java.util.Collection;
 import java.util.UUID;
 
-import static org.junit.Assert.*;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class AttachmentIntegrationTest {
 
@@ -37,19 +39,19 @@ public class AttachmentIntegrationTest {
                 "application/ternary", content);
         final Issue testIssue = new Issue();
         testIssue.setSubject("This is upload ticket!");
-        testIssue.getAttachments().add(attach1);
+        testIssue.addAttachment(attach1);
         final Issue createdIssue = mgr.createIssue(projectKey, testIssue);
         try {
-            final List<Attachment> attachments = createdIssue.getAttachments();
-            assertEquals(1, attachments.size());
-            final Attachment added = attachments.get(0);
-            assertEquals("test.bin", added.getFileName());
-            assertEquals("application/ternary", added.getContentType());
+            final Collection<Attachment> attachments = createdIssue.getAttachments();
+            assertThat(attachments.size()).isEqualTo(1);
+            final Attachment added = attachments.iterator().next();
+            assertThat(added.getFileName()).isEqualTo("test.bin");
+            assertThat(added.getContentType()).isEqualTo("application/ternary");
             final byte[] receivedContent = mgr.downloadAttachmentContent(added);
             assertArrayEquals(content, receivedContent);
 
             Issue issueById = mgr.getIssueById(createdIssue.getId(), RedmineManager.INCLUDE.attachments);
-            assertEquals(1, issueById.getAttachments().size());
+            assertThat(issueById.getAttachments().size()).isEqualTo(1);
         } finally {
             mgr.deleteIssue(createdIssue.getId());
         }

--- a/src/test/java/com/taskadapter/redmineapi/Simple.java
+++ b/src/test/java/com/taskadapter/redmineapi/Simple.java
@@ -1,12 +1,21 @@
 package com.taskadapter.redmineapi;
 
-import java.io.IOException;
-import java.util.List;
-
 import com.taskadapter.redmineapi.RedmineManager.INCLUDE;
-import com.taskadapter.redmineapi.bean.*;
+import com.taskadapter.redmineapi.bean.Attachment;
+import com.taskadapter.redmineapi.bean.Issue;
+import com.taskadapter.redmineapi.bean.IssueCategory;
+import com.taskadapter.redmineapi.bean.IssueRelation;
+import com.taskadapter.redmineapi.bean.News;
+import com.taskadapter.redmineapi.bean.Project;
+import com.taskadapter.redmineapi.bean.SavedQuery;
+import com.taskadapter.redmineapi.bean.User;
+import com.taskadapter.redmineapi.bean.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 
 public class Simple {
 	private static final Logger logger = LoggerFactory.getLogger(Simple.class);
@@ -56,7 +65,7 @@ public class Simple {
 				"application/ternary", content);
 		final Issue testIssue = new Issue();
 		testIssue.setSubject("This is upload ticket!");
-		testIssue.getAttachments().add(attach1);
+		testIssue.addAttachment(attach1);
 		final Project tmpProject = new Project();
 		tmpProject.setIdentifier("uploadtmpproject");
 		tmpProject.setName("Upload project");
@@ -136,9 +145,8 @@ public class Simple {
 	private static void getIssueWithRelations(RedmineManager mgr)
 			throws RedmineException {
 		Issue issue = mgr.getIssueById(22751, INCLUDE.relations);
-		List<IssueRelation> r = issue.getRelations();
+		Collection<IssueRelation> r = issue.getRelations();
 		logger.debug("Retrieved relations " + r);
-
 	}
 
 	@SuppressWarnings("unused")

--- a/src/test/java/com/taskadapter/redmineapi/bean/IssueTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/IssueTest.java
@@ -1,0 +1,18 @@
+package com.taskadapter.redmineapi.bean;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class IssueTest {
+    @Test
+    public void customFieldWithDuplicateIDReplacesTheOldOne() {
+        Issue issue = new Issue();
+        CustomField field = new CustomField(5, "name1", "value1");
+        CustomField duplicateField = new CustomField(5, "name1", "value1");
+        assertThat(issue.getCustomFields().size()).isEqualTo(0);
+        issue.addCustomField(field);
+        issue.addCustomField(duplicateField);
+        assertThat(issue.getCustomFields().size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/taskadapter/redmineapi/bean/UserTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/UserTest.java
@@ -1,0 +1,18 @@
+package com.taskadapter.redmineapi.bean;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class UserTest {
+    @Test
+    public void customFieldWithDuplicateIDReplacesTheOldOne() {
+        User user = new User();
+        CustomField field = new CustomField(5, "name1", "value1");
+        CustomField duplicateField = new CustomField(5, "name1", "value1");
+        assertThat(user.getCustomFields().size()).isEqualTo(0);
+        user.addCustomField(field);
+        user.addCustomField(duplicateField);
+        assertThat(user.getCustomFields().size()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
to avoid "duplicate ID" exception when several custom fields
with the same ID are added to the list due to programmer's error.

Closed direct access to CustomFields and other collections in Issue, User and other beans.

Added Fest Assert library to use assertThat() style assertions in tests.
