### PR TITLE
Fix setting project on existing issue

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -293,9 +293,20 @@ public class RedmineJSONBuilder {
 					.getAssignee().getId());
 		JsonOutput.addIfNotNull(writer, "priority_id", issue.getPriorityId());
 		JsonOutput.addIfNotNull(writer, "done_ratio", issue.getDoneRatio());
-		if (issue.getProject() != null)
+		if (issue.getProject() != null) {
+                    // Checked in Redmine 2.6.0: updating issues based on 
+                    // identifier fails and only using the project id works.
+                    // As the identifier usage is used in several places, this
+                    // case selection is introduced. The identifier is
+                    // used, if no real ID is provided
+                    if(issue.getProject().getId() != null) {
 			JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
-					.getIdentifier());
+					.getId());
+                    } else {
+                        JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
+                                .getIdentifier());
+                    }
+                }
 		if (issue.getAuthor() != null)
 			JsonOutput.addIfNotNull(writer, "author_id", issue.getAuthor()
 					.getId());

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
@@ -56,6 +56,7 @@ public class IssueManagerTest {
     private static IssueManager issueManager;
     private static ProjectManager projectManager;
     private static String projectKey;
+    private static String projectKey2;
     private static RedmineManager mgr;
     private static UserManager userManager;
 
@@ -66,11 +67,13 @@ public class IssueManagerTest {
         issueManager = mgr.getIssueManager();
         projectManager = mgr.getProjectManager();
         projectKey = IntegrationTestHelper.createProject(mgr);
+        projectKey2 = IntegrationTestHelper.createProject(mgr);
     }
 
     @AfterClass
     public static void oneTimeTearDown() {
         IntegrationTestHelper.deleteProject(mgr, projectKey);
+        IntegrationTestHelper.deleteProject(mgr, projectKey2);
     }
 
     @Test
@@ -1287,5 +1290,18 @@ public class IssueManagerTest {
 
         Issue issueWithUpdatedStatus = issueManager.getIssueById(retrievedIssue.getId());
         assertThat(issueWithUpdatedStatus.getStatusId()).isEqualTo(newStatusId);
+    }
+    
+    @Test
+    public void changeProject() throws RedmineException {
+        Project project1 = mgr.getProjectManager().getProjectByKey(projectKey);
+        Project project2 = mgr.getProjectManager().getProjectByKey(projectKey2);
+        Issue issue = createIssues(issueManager, projectKey, 1).get(0);
+        Issue retrievedIssue = issueManager.getIssueById(issue.getId());
+        assertEquals(retrievedIssue.getProject(), project1);
+        issue.setProject(project2);
+        issueManager.update(issue);
+        retrievedIssue = issueManager.getIssueById(issue.getId());
+        assertEquals(retrievedIssue.getProject(), project2);
     }
 }


### PR DESCRIPTION
While working on netbeans redmine integration, I noticed, that I failed to change the project for an issue. I could track it down to using the project identifier, instead of the id of the project when creating the request object.

I created a unittest, that demonstrates the problem and verifies the fix.

The fix is intended to support the "old" way and the new way - the idea: As long a project ID is present, use that, if it is not present, fall back to the identifier. All unittests still pass.