### PR TITLE
Implement retrieving custom field definitions

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/CustomFieldManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/CustomFieldManager.java
@@ -1,0 +1,25 @@
+package com.taskadapter.redmineapi;
+
+import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
+import com.taskadapter.redmineapi.internal.Transport;
+
+import java.util.List;
+
+/**
+ * CustomFieldManager is currently read-only.
+ * 
+ * Please see http://www.redmine.org/issues/9664 for details.
+ */
+public class CustomFieldManager {
+    private final Transport transport;
+
+    CustomFieldManager(Transport transport) {
+        this.transport = transport;
+    }
+
+    public List<CustomFieldDefinition> getCustomFieldDefinitions()
+            throws RedmineException {
+        return transport.getObjectsList(CustomFieldDefinition.class);
+    }
+
+}

--- a/src/main/java/com/taskadapter/redmineapi/CustomFieldManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/CustomFieldManager.java
@@ -17,6 +17,13 @@ public class CustomFieldManager {
         this.transport = transport;
     }
 
+    /**
+     * Fetch custom field definitions from server.
+     * 
+     * @throws com.taskadapter.redmineapi.RedmineException
+     * @since Redmine 2.4
+     * @return List of custom field definitions
+     */
     public List<CustomFieldDefinition> getCustomFieldDefinitions()
             throws RedmineException {
         return transport.getObjectsList(CustomFieldDefinition.class);

--- a/src/main/java/com/taskadapter/redmineapi/RedmineManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/RedmineManager.java
@@ -20,13 +20,14 @@ import com.taskadapter.redmineapi.internal.Transport;
 
 public class RedmineManager {
 
-	private final Transport transport;
+    private final Transport transport;
     private final Runnable shutdownListener;
     private final IssueManager issueManager;
     private final AttachmentManager attachmentManager;
     private final UserManager userManager;
     private final ProjectManager projectManager;
     private final MembershipManager membershipManager;
+    private final CustomFieldManager customFieldManager;
     private final WikiManager wikiManager;
 
     RedmineManager(Transport transport, Runnable shutdownListener) {
@@ -37,6 +38,7 @@ public class RedmineManager {
         projectManager = new ProjectManager(transport);
         membershipManager = new MembershipManager(transport);
         wikiManager = new WikiManager(transport);
+        customFieldManager = new CustomFieldManager(transport);
         this.shutdownListener = shutdownListener;
     }
 
@@ -62,6 +64,10 @@ public class RedmineManager {
 
     public MembershipManager getMembershipManager() {
         return membershipManager;
+    }
+
+    public CustomFieldManager getCustomFieldManager() {
+        return customFieldManager;
     }
 
     /**

--- a/src/main/java/com/taskadapter/redmineapi/bean/CustomFieldDefinition.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/CustomFieldDefinition.java
@@ -146,28 +146,22 @@ public class CustomFieldDefinition {
     public List<Role> getRoles() {
         return roles;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         CustomFieldDefinition that = (CustomFieldDefinition) o;
 
-        if (id != that.id) {
-            return false;
-        }
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        return id;
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override

--- a/src/main/java/com/taskadapter/redmineapi/bean/CustomFieldDefinition.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/CustomFieldDefinition.java
@@ -1,0 +1,184 @@
+package com.taskadapter.redmineapi.bean;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomFieldDefinition {
+
+    private Integer id;
+    private String name;
+    private String customizedType;
+    private String fieldFormat;
+    private String regexp;
+    private Integer minLength;
+    private Integer maxLength;
+    private boolean required;
+    private boolean filter;
+    private boolean searchable;
+    private boolean multiple;
+    private String defaultValue;
+    private boolean visible;
+    private final List<String> possibleValues = new ArrayList<String>();
+    private final List<Tracker> trackers = new ArrayList<Tracker>();
+    private final List<Role> roles = new ArrayList<Role>();
+
+    /**
+     * Use CustomFieldDefinitionFactory to create instances of this class.
+     *
+     * @param id database ID.
+     */
+    CustomFieldDefinition(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCustomizedType() {
+        return customizedType;
+    }
+
+    public void setCustomizedType(String customizedType) {
+        this.customizedType = customizedType;
+    }
+
+    public String getFieldFormat() {
+        return fieldFormat;
+    }
+
+    public void setFieldFormat(String fieldFormat) {
+        this.fieldFormat = fieldFormat;
+    }
+
+    public String getRegexp() {
+        return regexp;
+    }
+
+    public void setRegexp(String regexp) {
+        this.regexp = regexp;
+    }
+
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public boolean isFilter() {
+        return filter;
+    }
+
+    public void setFilter(Boolean filter) {
+        this.filter = filter;
+    }
+
+    public boolean isSearchable() {
+        return searchable;
+    }
+
+    public void setSearchable(Boolean searchable) {
+        this.searchable = searchable;
+    }
+
+    public boolean isMultiple() {
+        return multiple;
+    }
+
+    public void setMultiple(Boolean multiple) {
+        this.multiple = multiple;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(Boolean visible) {
+        this.visible = visible;
+    }
+
+    public List<String> getPossibleValues() {
+        return possibleValues;
+    }
+
+    public List<Tracker> getTrackers() {
+        return trackers;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CustomFieldDefinition that = (CustomFieldDefinition) o;
+
+        if (id != that.id) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomFieldDefinition{" + "id=" + id + ", name=" + name +
+                ", customizedType=" + customizedType + ", fieldFormat=" +
+                fieldFormat + ", regexp=" + regexp + ", minLength=" + minLength +
+                ", maxLength=" + maxLength + ", required=" + required +
+                ", filter=" + filter + ", searchable=" + searchable +
+                ", multiple=" + multiple + ", defaultValue=" + defaultValue +
+                ", visible=" + visible + ", possibleValues=" + possibleValues +
+                ", trackers=" + trackers + ", roles=" + roles + '}';
+    }
+}

--- a/src/main/java/com/taskadapter/redmineapi/bean/CustomFieldDefinitionFactory.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/CustomFieldDefinitionFactory.java
@@ -1,0 +1,8 @@
+package com.taskadapter.redmineapi.bean;
+
+public class CustomFieldDefinitionFactory {
+
+    public static CustomFieldDefinition create(Integer id) {
+        return new CustomFieldDefinition(id);
+    }
+}

--- a/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
@@ -6,6 +6,7 @@ import com.taskadapter.redmineapi.RedmineException;
 import com.taskadapter.redmineapi.RedmineFormatException;
 import com.taskadapter.redmineapi.RedmineInternalError;
 import com.taskadapter.redmineapi.RedmineManager;
+import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
 import com.taskadapter.redmineapi.bean.Group;
 import com.taskadapter.redmineapi.bean.Identifiable;
 import com.taskadapter.redmineapi.bean.Issue;
@@ -158,6 +159,10 @@ public final class Transport {
                 WikiPageDetail.class,
                 config("wiki_page", null, null, RedmineJSONParser.WIKI_PAGE_DETAIL_PARSER)
         );
+        OBJECT_CONFIGS.put(
+                CustomFieldDefinition.class,
+                config("custom_field", "custom_fields", null,
+                        RedmineJSONParser.CUSTOM_FIELD_DEFINITION_PARSER));
     }
 
 	private final URIConfigurator configurator;

--- a/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
@@ -2,6 +2,7 @@ package com.taskadapter.redmineapi.internal;
 
 import com.taskadapter.redmineapi.RedmineInternalError;
 import com.taskadapter.redmineapi.bean.Attachment;
+import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
 import com.taskadapter.redmineapi.bean.Group;
 import com.taskadapter.redmineapi.bean.Issue;
 import com.taskadapter.redmineapi.bean.IssueCategory;
@@ -63,6 +64,7 @@ public class URIConfigurator {
 		urls.put(Watcher.class, "watchers");
         urls.put(WikiPage.class, "wiki/index");
         urls.put(WikiPageDetail.class, "wiki");
+                urls.put(CustomFieldDefinition.class, "custom_fields");
 	}
 
 	private final URL baseURL;

--- a/src/test/java/com/taskadapter/redmineapi/CustomFieldDefinitionsTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/CustomFieldDefinitionsTest.java
@@ -1,0 +1,114 @@
+package com.taskadapter.redmineapi;
+
+import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
+import com.taskadapter.redmineapi.internal.RedmineJSONParser;
+import com.taskadapter.redmineapi.internal.json.JsonInput;
+import java.io.IOException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import org.json.JSONException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test CustomFeildDefinitons API - the API is only read-only (as of 2.6.0),
+ * so the tests asume a preprogrammed configuration.
+ * 
+ * Exactly two custom fields are defined (from IssueManagerTest#testCustomFields:
+ *   - id: 1, customized_type: issue, name: my_custom_1, type: string
+ *   - id: 2, customized_type: issue, name: custom_boolean_1, type: bool
+ */
+public class CustomFieldDefinitionsTest {
+    private static final String CUSTOM_FIELDS_FILE = "custom_fields.json";
+    private static RedmineManager mgr;
+    private static CustomFieldManager customFieldManager;
+
+    @BeforeClass
+    public static void oneTimeSetup() {
+        mgr = IntegrationTestHelper.createRedmineManager();
+        customFieldManager = mgr.getCustomFieldManager();
+    }
+
+    @Test
+    public void testGetCustomFields() throws RedmineException {
+        List<CustomFieldDefinition> definitions = customFieldManager.getCustomFieldDefinitions();
+        assertEquals(definitions.size(), 2);
+        for(CustomFieldDefinition cfd: definitions) {
+            if(cfd.getId() == 1) {
+                assertEquals(cfd.getCustomizedType(), "issue");
+                assertEquals(cfd.getName(), "my_custom_1");
+                assertEquals(cfd.getFieldFormat(), "string");
+            } else if (cfd.getId() == 2) {
+                assertEquals(cfd.getCustomizedType(), "issue");
+                assertEquals(cfd.getName(), "custom_boolean_1");
+                assertEquals(cfd.getFieldFormat(), "bool");
+            }
+        }
+    }
+    
+    @Test
+    public void testDataFormat() throws IOException, JSONException {
+        String str = MyIOUtils.getResourceAsString(CUSTOM_FIELDS_FILE);
+        List<CustomFieldDefinition> definitions = JsonInput.getListOrEmpty(
+					RedmineJSONParser.getResponse(str),
+                                        "custom_fields",
+					RedmineJSONParser.CUSTOM_FIELD_DEFINITION_PARSER);
+        assertEquals(definitions.get(0).getId(), (Integer) 1);
+        assertEquals(definitions.get(0).getName(), "my_custom_1");
+        assertEquals(definitions.get(0).getCustomizedType(), "issue");
+        assertEquals(definitions.get(0).getFieldFormat(), "string");
+        assertEquals(definitions.get(0).getRegexp(), "some.*");
+        assertEquals(definitions.get(0).getMinLength(), (Integer) 5);
+        assertEquals(definitions.get(0).getMaxLength(), (Integer) 80);
+        assertEquals(definitions.get(0).isFilter(), true);
+        assertEquals(definitions.get(0).isSearchable(), true);
+        assertEquals(definitions.get(0).isMultiple(), false);
+        assertEquals(definitions.get(0).isVisible(), true);
+        assertEquals(definitions.get(0).isRequired(), false);
+        assertEquals(definitions.get(0).getDefaultValue(), "");
+        assertEquals(definitions.get(0).getPossibleValues().size(), 0);
+        assertEquals(definitions.get(0).getTrackers().get(0).getId(), (Integer)1);
+        assertEquals(definitions.get(0).getTrackers().get(1).getId(), (Integer)2);
+        assertEquals(definitions.get(0).getTrackers().get(2).getId(), (Integer)3);
+        assertEquals(definitions.get(0).getRoles().size(), 0);
+        
+        assertEquals(definitions.get(1).getId(), (Integer) 2);
+        assertEquals(definitions.get(1).getName(), "custom_boolean_1");
+        assertEquals(definitions.get(1).getCustomizedType(), "issue");
+        assertEquals(definitions.get(1).getFieldFormat(), "bool");
+        assertEquals(definitions.get(1).getRegexp(), "");
+        assertEquals(definitions.get(1).getMinLength(), null);
+        assertEquals(definitions.get(1).getMaxLength(), null);
+        assertEquals(definitions.get(1).isFilter(), false);
+        assertEquals(definitions.get(1).isSearchable(), false);
+        assertEquals(definitions.get(1).isMultiple(), false);
+        assertEquals(definitions.get(1).isVisible(), true);
+        assertEquals(definitions.get(1).isRequired(), false);
+        assertEquals(definitions.get(1).getDefaultValue(), "");
+        assertEquals(definitions.get(1).getPossibleValues().get(0), "1");
+        assertEquals(definitions.get(1).getPossibleValues().get(1), "0");
+        assertEquals(definitions.get(1).getTrackers().size(), 3);
+        assertEquals(definitions.get(1).getRoles().size(), 0);
+        
+        assertEquals(definitions.get(2).getId(), (Integer) 3);
+        assertEquals(definitions.get(2).getName(), "Test");
+        assertEquals(definitions.get(2).getCustomizedType(), "issue");
+        assertEquals(definitions.get(2).getFieldFormat(), "bool");
+        assertEquals(definitions.get(2).getRegexp(), "");
+        assertEquals(definitions.get(2).getMinLength(), null);
+        assertEquals(definitions.get(2).getMaxLength(), null);
+        assertEquals(definitions.get(2).isFilter(), false);
+        assertEquals(definitions.get(2).isSearchable(), false);
+        assertEquals(definitions.get(2).isMultiple(), false);
+        assertEquals(definitions.get(2).isVisible(), false);
+        assertEquals(definitions.get(2).isRequired(), true);
+        assertEquals(definitions.get(2).getDefaultValue(), "1");
+        assertEquals(definitions.get(2).getPossibleValues().get(0), "1");
+        assertEquals(definitions.get(2).getPossibleValues().get(1), "0");
+        assertEquals(definitions.get(2).getTrackers().size(), 0);
+        assertEquals(definitions.get(2).getRoles().get(0).getId(), (Integer) 4);
+    }
+
+}

--- a/src/test/resources/custom_fields.json
+++ b/src/test/resources/custom_fields.json
@@ -1,0 +1,68 @@
+{
+    "custom_fields": [{
+            "id": 1,
+            "name": "my_custom_1",
+            "customized_type": "issue",
+            "field_format": "string",
+            "regexp": "some.*",
+            "min_length": 5,
+            "max_length": 80,
+            "is_filter": true,
+            "searchable": true,
+            "default_value": "",
+            "visible": true,
+            "trackers": [{
+                    "id": 1,
+                    "name": "Bug"
+                }, {
+                    "id": 2,
+                    "name": "Feature"
+                }, {
+                    "id": 3,
+                    "name": "Support"
+                }],
+            "roles": []
+        }, {
+            "id": 2,
+            "name": "custom_boolean_1",
+            "customized_type": "issue",
+            "field_format": "bool",
+            "regexp": "",
+            "default_value": "",
+            "visible": true,
+            "possible_values": [{
+                    "value": "1"
+                }, {
+                    "value": "0"
+                }],
+            "trackers": [{
+                    "id": 1,
+                    "name": "Bug"
+                }, {
+                    "id": 2,
+                    "name": "Feature"
+                }, {
+                    "id": 3,
+                    "name": "Support"
+                }],
+            "roles": []
+        }, {
+            "id": 3,
+            "name": "Test",
+            "customized_type": "issue",
+            "field_format": "bool",
+            "regexp": "",
+            "default_value": "1",
+            "is_required":true,
+            "possible_values": [{
+                    "value": "1"
+                }, {
+                    "value": "0"
+                }],
+            "trackers": [],
+            "roles": [{
+                    "id": 4,
+                    "name": "Developer"
+                }]
+        }]
+}


### PR DESCRIPTION
The attached changes utilize the custom_field-api created by http://www.redmine.org/issues/9664 to retrieve the field definitions from the redmine instance.

The existing unittest still work, two new unittests verify the new functionality.