### PR TITLE
Fix javadoc for building with jdk8

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/IssueManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/IssueManager.java
@@ -101,6 +101,7 @@ public class IssueManager {
      *   issueToCreate.setSubject("This is the summary line 123");
      *   Issue newIssue = mgr.createIssue(PROJECT_KEY, issueToCreate);
      * }
+     * </pre>
      *
      * @param projectKey The project "identifier". This is a string key like "project-ABC", NOT a database numeric ID.
      * @param issue      the Issue object to create on the server.
@@ -131,7 +132,7 @@ public class IssueManager {
      * @param projectKey ignored if NULL
      * @param queryId    id of the saved query in Redmine. the query must be accessible to the user
      *                   represented by the API access key (if the Redmine project requires authorization).
-     *                   This parameter is <b>optional<b>, NULL can be provided to get all available issues.
+     *                   This parameter is <b>optional</b>, NULL can be provided to get all available issues.
      * @return list of Issue objects
      * @throws RedmineAuthenticationException invalid or no API access key is used with the server, which
      *                                 requires authorization. Check the constructor arguments.
@@ -252,7 +253,7 @@ public class IssueManager {
     }
 
     /**
-     * creates a new {@link IssueCategory} for the {@link Project} contained. <br/>
+     * creates a new {@link IssueCategory} for the {@link Project} contained. <br>
      * Pre-condition: the attribute {@link Project} for the {@link IssueCategory} must
      * not be null!
      *
@@ -275,7 +276,7 @@ public class IssueManager {
     }
 
     /**
-     * deletes an {@link IssueCategory}. <br/>
+     * deletes an {@link IssueCategory}. <br>
      *
      * @param category the {@link IssueCategory}.
      * @throws RedmineAuthenticationException thrown in case something went wrong while trying to login
@@ -311,8 +312,8 @@ public class IssueManager {
 
     /**
      * Get "saved queries" for the given project available to the current user.
-     * <p/>
-     * <p>This REST API feature was added in Redmine 1.3.0. See http://www.redmine.org/issues/5737
+     *
+     * <p>This REST API feature was added in Redmine 1.3.0. See http://www.redmine.org/issues/5737</p>
      */
     public List<SavedQuery> getSavedQueries(String projectKey) throws RedmineException {
         Set<NameValuePair> params = new HashSet<NameValuePair>();
@@ -326,8 +327,8 @@ public class IssueManager {
 
     /**
      * Get all "saved queries" available to the current user.
-     * <p/>
-     * <p>This REST API feature was added in Redmine 1.3.0. See http://www.redmine.org/issues/5737
+     * 
+     * <p>This REST API feature was added in Redmine 1.3.0. See http://www.redmine.org/issues/5737</p>
      */
     public List<SavedQuery> getSavedQueries() throws RedmineException {
         return transport.getObjectsList(SavedQuery.class);

--- a/src/main/java/com/taskadapter/redmineapi/ProjectManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/ProjectManager.java
@@ -20,7 +20,7 @@ public class ProjectManager {
 
     /**
      * Sample usage:
-     * <p/>
+     * 
      * <pre>
      * {@code
      * 	Project project = new Project();
@@ -95,7 +95,7 @@ public class ProjectManager {
     }
 
     /**
-     * creates a new {@link com.taskadapter.redmineapi.bean.Version} for the {@link Project} contained. <br/>
+     * creates a new {@link com.taskadapter.redmineapi.bean.Version} for the {@link Project} contained. <br>
      * Pre-condition: the attribute {@link Project} for the {@link com.taskadapter.redmineapi.bean.Version} must
      * not be null!
      *
@@ -118,7 +118,7 @@ public class ProjectManager {
     }
 
     /**
-     * deletes a new {@link Version} from the {@link Project} contained. <br/>
+     * deletes a new {@link Version} from the {@link Project} contained. <br>
      *
      * @param version the {@link Version}.
      * @throws RedmineAuthenticationException thrown in case something went wrong while trying to login

--- a/src/main/java/com/taskadapter/redmineapi/RedmineManagerFactory.java
+++ b/src/main/java/com/taskadapter/redmineapi/RedmineManagerFactory.java
@@ -74,7 +74,7 @@ public final class RedmineManagerFactory {
      *                     number. Example: http://demo.redmine.org:8080
      * @param apiAccessKey Redmine API access key. It is shown on "My Account" /
      *                     "API access key" webpage (check
-     *                     <i>http://redmine_server_url/my/account<i> URL). This
+     *                     <i>http://redmine_server_url/my/account</i> URL). This
      *                     parameter is <b>optional</b> (can be set to NULL) for Redmine
      *                     projects, which are "public".
      */
@@ -92,7 +92,7 @@ public final class RedmineManagerFactory {
      *                     number. Example: http://demo.redmine.org:8080
      * @param apiAccessKey Redmine API access key. It is shown on "My Account" /
      *                     "API access key" webpage (check
-     *                     <i>http://redmine_server_url/my/account<i> URL). This
+     *                     <i>http://redmine_server_url/my/account</i> URL). This
      *                     parameter is <b>optional</b> (can be set to NULL) for Redmine
      *                     projects, which are "public".
      * @param config       transport configuration.
@@ -199,9 +199,10 @@ public final class RedmineManagerFactory {
      * is usefull for some short-time communication. Common scerario for this
      * method is to create RedmineManager, load/update some tasks and then
      * shutdown all the manager.
-     * <p/>
+     * <p>
      * Note that this configuration will shutdown connection manager when
      * shutdown will be called on RedmineManager instance.
+     * </p>
      */
     public static TransportConfiguration createShortTermConfig(
             final ClientConnectionManager connectionManager) {
@@ -218,10 +219,10 @@ public final class RedmineManagerFactory {
      * Creates a transport which supports connection eviction. This transport
      * can be used in a long-term interactive scenarios where actual redmine
      * communications are interleaved with user interactios (data input).
-     * <p/>
+     * <p>
      * Shutting down redmine manager will also shut down provided connection
      * manager.
-     *
+     * </p>
      * @param connectionManager connection manager to use.
      * @param idleTimeout       idle timeout for connection before eviction, seconds.
      * @param evictionCheck     eviction check interval, seconds.

--- a/src/main/java/com/taskadapter/redmineapi/WikiManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/WikiManager.java
@@ -27,7 +27,7 @@ public class WikiManager {
     }
 
     /**
-     * @param @param projectKey the key of the project (like "TEST-12") we want the wiki page from
+     * @param projectKey the key of the project (like "TEST-12") we want the wiki page from
      * @param pageTitle   The name of the page
      *
      * @return the wiki page titled with the name passed as parameter

--- a/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
@@ -333,7 +333,7 @@ public class Issue implements Identifiable {
      *
      * @return relations or EMPTY collection if no relations, never returns NULL
      *
-     * @see com.taskadapter.redmineapi.RedmineManager#getIssueById(Integer id, INCLUDE... include)
+     * @see com.taskadapter.redmineapi.IssueManager#getIssueById(Integer id, Include... include)
      */
     public Collection<IssueRelation> getRelations() {
         return Collections.unmodifiableCollection(relations);


### PR DESCRIPTION
I build redmine-java-api with openjdk8 and the javac/javadoc version is much more strict with regard to javadoc, than previous versions. The attached changes are only fixing the reported errors, to make it possible to compile with a recent JDK.
