### PR TITLE
Workaround: redmine 2.6 return invalid structure for empty custom field

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -521,15 +521,26 @@ public class RedmineJSONParser {
 		final CustomField result = CustomFieldFactory.create(JsonInput.getInt(content, "id"));
 		result.setName(JsonInput.getStringOrNull(content, "name"));
 
-		if (!content.has("multiple"))
+		if (!content.has("multiple")) {
 			result.setValue(JsonInput.getStringOrNull(content, "value"));
-		else {
-			JSONArray tmp = JsonInput.getArrayOrNull(content, "value");
-			ArrayList<String> strings = new ArrayList<String>();
-			for (int i = 0; i < tmp.length(); i++) {
-				strings.add(String.valueOf(tmp.get(i)));
-			}
-			result.setValues(strings);
+                } else {
+                        ArrayList<String> strings = new ArrayList<String>();
+                        Object value = content.get("value");
+                        if(value instanceof JSONArray) {
+                            JSONArray tmp = (JSONArray) value;
+                            for (int i = 0; i < tmp.length(); i++) {
+                                    strings.add(String.valueOf(tmp.get(i)));
+                            }   
+                        } else {
+                            // Known issue: Under the condition:
+                            // - issue is newly created
+                            // - custom_field is multi-field
+                            // - custom_field is set to an empty list or null
+                            // Then:
+                            // - the return structure has "multiple" set
+                            // - but the value is the empty string
+                        }
+                        result.setValues(strings);
 		}
 
 		return result;

--- a/src/test/java/com/taskadapter/redmineapi/CustomFieldDefinitionsTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/CustomFieldDefinitionsTest.java
@@ -4,6 +4,7 @@ import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
 import com.taskadapter.redmineapi.internal.RedmineJSONParser;
 import com.taskadapter.redmineapi.internal.json.JsonInput;
 import java.io.IOException;
+import java.util.Arrays;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -19,6 +20,8 @@ import static org.junit.Assert.*;
  * Exactly two custom fields are defined (from IssueManagerTest#testCustomFields:
  *   - id: 1, customized_type: issue, name: my_custom_1, type: string
  *   - id: 2, customized_type: issue, name: custom_boolean_1, type: bool
+ *   - id: 3, customized_type: issue, name: custom_multi_list, type: list, 
+ *            multiple: true, possible_values: V1, V2, V3, default: V2
  */
 public class CustomFieldDefinitionsTest {
     private static final String CUSTOM_FIELDS_FILE = "custom_fields_redmine_2.3.json";
@@ -34,7 +37,7 @@ public class CustomFieldDefinitionsTest {
     @Test
     public void testGetCustomFields() throws RedmineException {
         List<CustomFieldDefinition> definitions = customFieldManager.getCustomFieldDefinitions();
-        assertEquals(definitions.size(), 2);
+        assertEquals(definitions.size(), 3);
         for(CustomFieldDefinition cfd: definitions) {
             if(cfd.getId() == 1) {
                 assertEquals(cfd.getCustomizedType(), "issue");
@@ -44,6 +47,13 @@ public class CustomFieldDefinitionsTest {
                 assertEquals(cfd.getCustomizedType(), "issue");
                 assertEquals(cfd.getName(), "custom_boolean_1");
                 assertEquals(cfd.getFieldFormat(), "bool");
+            } else if (cfd.getId() == 3) {
+                assertEquals(cfd.getCustomizedType(), "issue");
+                assertEquals(cfd.getName(), "custom_multi_list");
+                assertEquals(cfd.getFieldFormat(), "list");
+                assertEquals(cfd.getDefaultValue(), "V2");
+                assertEquals(cfd.getPossibleValues(), Arrays.asList("V1", "V2", "V3"));
+                assertTrue(cfd.isMultiple());
             }
         }
     }

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
@@ -37,6 +37,9 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.taskadapter.redmineapi.IssueHelper.createIssues;
+import com.taskadapter.redmineapi.bean.CustomField;
+import java.util.Arrays;
+import java.util.Collections;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1187,12 +1190,29 @@ public class IssueManagerTest {
     @Test
     public void testCustomFields() throws Exception {
         Issue issue = createIssues(issueManager, projectKey, 1).get(0);
-        // default empty values
-        assertThat(issue.getCustomFields().size()).isEqualTo(2);
 
-        // TODO update this!
-        int id1 = 1; // TODO this is pretty much a hack, we don't generally know
-        // these ids!
+        // TODO this needs to be reworked, when Redmine gains a real CRUD interface for custom fields
+        //
+        // To test right now the test system needs:
+        //
+        // Custom Field with ID 1 needs to be:
+        // name: my_custom_1
+        // format: Text (string)
+        // for all project, for all trackers
+        //
+        // Custom Field with ID 2 needs to be:
+        // name: custom_boolean_1
+        // format: Boolean (bool)
+        // 
+        // Custom Field with ID 3 needs to be:
+        // name: custom_multi_list
+        // format: List (list)
+        // multiple values: enabled
+        // possible values: V1, V2, V3
+        // default value: V2
+        //
+        // All fields: need to be issue fields, for all project, for all trackers
+        int id1 = 1;
         String custom1FieldName = "my_custom_1";
         String custom1Value = "some value 123";
 
@@ -1200,6 +1220,9 @@ public class IssueManagerTest {
         String custom2FieldName = "custom_boolean_1";
         String custom2Value = "true";
 
+        // default empty values
+        assertThat(issue.getCustomFields().size()).isEqualTo(3);
+        
         issue.clearCustomFields();
 
         issue.addCustomField(CustomFieldFactory.create(id1, custom1FieldName, custom1Value));
@@ -1207,13 +1230,77 @@ public class IssueManagerTest {
         issueManager.update(issue);
 
         Issue updatedIssue = issueManager.getIssueById(issue.getId());
-        assertThat(updatedIssue.getCustomFields().size()).isEqualTo(2);
+        assertThat(updatedIssue.getCustomFields().size()).isEqualTo(3);
         assertEquals(custom1Value,
                 updatedIssue.getCustomField(custom1FieldName));
         assertEquals(custom2Value,
                 updatedIssue.getCustomField(custom2FieldName));
     }
-
+  
+    /**
+     * @see com.taskadapter.redmineapi.IssueManagerTest.testCustomFields()
+     */
+    @Test
+    public void testCustomFieldsMultipleValues() throws Exception {
+        Issue newIssue;
+        Issue createdIssue;
+        CustomField customField;
+        
+        // Basic check 1: default value is used, when custom field is not supplied
+        // when creating issue
+        newIssue = new Issue();
+        newIssue.setSubject("test");
+        createdIssue = issueManager.createIssue(projectKey, newIssue);
+        customField = createdIssue.getCustomFieldById(3);
+        assertTrue(customField != null);
+        assertEquals(1, customField.getValues().size());
+        assertEquals(customField.getValues().get(0), "V2");
+        issueManager.deleteIssue(createdIssue.getId());
+        
+        // Basic check 2: Set one value
+        newIssue = new Issue();
+        newIssue.setSubject("test");
+        customField = CustomFieldFactory.create(3);
+        customField.setValues(Collections.singletonList("V1"));
+        newIssue.addCustomField(customField);
+        createdIssue = issueManager.createIssue(projectKey, newIssue);
+        customField = createdIssue.getCustomFieldById(3);
+        assertTrue(customField != null);
+        assertEquals(1, customField.getValues().size());
+        assertEquals(customField.getValues().get(0), "V1");
+        issueManager.deleteIssue(createdIssue.getId());
+        
+        
+        // Basic check 3: Set multiple values 
+        // (check for https://github.com/taskadapter/redmine-java-api/issues/54)
+        newIssue = new Issue();
+        newIssue.setSubject("test");
+        customField = CustomFieldFactory.create(3);
+        customField.setValues(Arrays.asList("V1", "V3"));
+        newIssue.addCustomField(customField);
+        createdIssue = issueManager.createIssue(projectKey, newIssue);
+        customField = createdIssue.getCustomFieldById(3);
+        assertTrue(customField != null);
+        assertEquals(2, customField.getValues().size());
+        List<String> values = new ArrayList<String>(customField.getValues());
+        Collections.sort(values);
+        assertEquals(customField.getValues().get(0), "V1");
+        assertEquals(customField.getValues().get(1), "V3");
+        issueManager.deleteIssue(createdIssue.getId());
+        
+        // Basic check 4: Create issue with empty list (known problem in redmine 2.6)
+        newIssue = new Issue();
+        newIssue.setSubject("test");
+        customField = CustomFieldFactory.create(3);
+        customField.setValues(Collections.EMPTY_LIST);
+        newIssue.addCustomField(customField);
+        createdIssue = issueManager.createIssue(projectKey, newIssue);
+        customField = createdIssue.getCustomFieldById(3);
+        assertTrue(customField != null);
+        assertEquals(0, customField.getValues().size());
+        issueManager.deleteIssue(createdIssue.getId());
+    }
+    
     @Ignore
     @Test
     public void testChangesets() throws RedmineException {


### PR DESCRIPTION
Known issue: Under the condition:

    issue is newly created
    custom_field is multi-field
    custom_field is set to an empty list or null

Then:

    the return structure has "multiple" set
    but the value is the empty string

I modified the unittest, to test handling of multi-value custom fields. To do this I modified the test, to check a third custom value (so the redmine instance, this is tested against needs to be modified).

See comment in testCustomFields for the new field.

The unittest not only covers the new work around, but also introduces tests that were requested for pull request #54.

Unittests all run through (after adding the third custom field of course)