### PR TITLE
Implement clearing issue fields

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
@@ -4,14 +4,31 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 /**
  * Redmine's Issue
  */
 public class Issue implements Identifiable {
-
+    public static final String PROP_SUBJECT = "subject";
+    public static final String PROP_PARENT_ID = "parentId";
+    public static final String PROP_ESTIMATED_HOURS = "estimatedHours";
+    public static final String PROP_SPENT_HOURS = "spentHours";
+    public static final String PROP_ASSIGNEE = "assignee";
+    public static final String PROP_PRIORITY_ID = "priorityId";
+    public static final String PROP_DONE_RATIO = "doneRatio";
+    public static final String PROP_PROJECT = "project";
+    public static final String PROP_AUTHOR = "author";
+    public static final String PROP_START_DATE = "startDate";
+    public static final String PROP_DUE_DATE = "dueDate";
+    public static final String PROP_TRACKER = "tracker";
+    public static final String PROP_DESCRIPTION = "description";
+    public static final String PROP_CREATED_ON = "createdOn";
+    public static final String PROP_UPDATED_ON = "updatedOn";
+    public static final String PROP_STATUS_ID = "statusId";
+    public static final String PROP_TARGET_VERSION = "targetVersion";
+    public static final String PROP_CATEGORY = "category";
+    
     /**
      * @param id database ID.
      */
@@ -54,6 +71,10 @@ public class Issue implements Identifiable {
     private final Set<Changeset> changesets = new HashSet<Changeset>();
     private final Set<Watcher> watchers = new HashSet<Watcher>();
 
+    private boolean updateTracking = false;
+    // Package visible to be accessible by unittests
+    final Set<String> updated = new HashSet<String>();
+    
     /**
      * @param id database ID.
      */
@@ -70,6 +91,7 @@ public class Issue implements Identifiable {
     }
 
     public void setProject(Project project) {
+        updated.add(PROP_PROJECT);
         this.project = project;
     }
 
@@ -78,6 +100,7 @@ public class Issue implements Identifiable {
     }
 
     public void setDoneRatio(Integer doneRatio) {
+        updated.add(PROP_DONE_RATIO);
         this.doneRatio = doneRatio;
     }
 
@@ -98,6 +121,7 @@ public class Issue implements Identifiable {
     }
 
     public void setAssignee(User assignee) {
+        updated.add(PROP_ASSIGNEE);
         this.assignee = assignee;
     }
 
@@ -106,6 +130,7 @@ public class Issue implements Identifiable {
     }
 
     public void setEstimatedHours(Float estimatedTime) {
+        updated.add(PROP_ESTIMATED_HOURS);
         this.estimatedHours = estimatedTime;
     }
 
@@ -114,6 +139,7 @@ public class Issue implements Identifiable {
     }
 
     public void setSpentHours(Float spentHours) {
+         updated.add(PROP_SPENT_HOURS);
          this.spentHours = spentHours;
     }
 
@@ -127,6 +153,7 @@ public class Issue implements Identifiable {
     }
 
     public void setParentId(Integer parentId) {
+        updated.add(PROP_PARENT_ID);
         this.parentId = parentId;
     }
 
@@ -143,6 +170,7 @@ public class Issue implements Identifiable {
     }
 
     public void setSubject(String subject) {
+        updated.add(PROP_SUBJECT);
         this.subject = subject;
     }
 
@@ -151,6 +179,7 @@ public class Issue implements Identifiable {
     }
 
     public void setAuthor(User author) {
+        updated.add(PROP_AUTHOR);
         this.author = author;
     }
 
@@ -159,6 +188,7 @@ public class Issue implements Identifiable {
     }
 
     public void setStartDate(Date startDate) {
+        updated.add(PROP_START_DATE);
         this.startDate = startDate;
     }
 
@@ -167,6 +197,7 @@ public class Issue implements Identifiable {
     }
 
     public void setDueDate(Date dueDate) {
+        updated.add(PROP_DUE_DATE);
         this.dueDate = dueDate;
     }
 
@@ -175,6 +206,7 @@ public class Issue implements Identifiable {
     }
 
     public void setTracker(Tracker tracker) {
+        updated.add(PROP_TRACKER);
         this.tracker = tracker;
     }
 
@@ -186,6 +218,7 @@ public class Issue implements Identifiable {
     }
 
     public void setDescription(String description) {
+        updated.add(PROP_DESCRIPTION);
         this.description = description;
     }
 
@@ -194,6 +227,7 @@ public class Issue implements Identifiable {
     }
 
     public void setCreatedOn(Date createdOn) {
+        updated.add(PROP_CREATED_ON);
         this.createdOn = createdOn;
     }
 
@@ -202,6 +236,7 @@ public class Issue implements Identifiable {
     }
 
     public void setUpdatedOn(Date updatedOn) {
+        updated.add(PROP_UPDATED_ON);
         this.updatedOn = updatedOn;
     }
 
@@ -210,6 +245,7 @@ public class Issue implements Identifiable {
     }
 
     public void setStatusId(Integer statusId) {
+        updated.add(PROP_STATUS_ID);
         this.statusId = statusId;
     }
 
@@ -348,6 +384,7 @@ public class Issue implements Identifiable {
     }
 
     public void setPriorityId(Integer priorityId) {
+        updated.add(PROP_PRIORITY_ID);
         this.priorityId = priorityId;
     }
 
@@ -371,6 +408,7 @@ public class Issue implements Identifiable {
     }
 
     public void setTargetVersion(Version version) {
+        updated.add(PROP_TARGET_VERSION);
         this.targetVersion = version;
     }
 
@@ -379,6 +417,61 @@ public class Issue implements Identifiable {
     }
 
     public void setCategory(IssueCategory category) {
+        updated.add(PROP_CATEGORY);
         this.category = category;
+    }
+    
+    /**
+     * Check update state of an issue property.
+     * 
+     * @param property name of property to check, see the static PROP_* fields of this class
+     * @return true if property was changed since last invocation of setUpdateTracking
+     */
+    public boolean wasUpdated(String property) {
+        return updated.contains(property);
+    }
+
+    public boolean isUpdateTracking() {
+        return updateTracking;
+    }
+
+    /**
+     * Clear/set update tracking.
+     * 
+     * <p>updateTracking is only a state - calling this method does not change
+     * the behaviour of the issue object, but is an indicator for other
+     * methods working with issues.</p>
+     * 
+     * <p>It is the intention to provide a backwards compatible way of tracking
+     * changes in the object state. Before the introduction of this updateTracking
+     * null was used as an indicator of an unchanged value. This breaks when
+     * trying to set the value to null (parent issue, duedate, ...).</p>
+     * 
+     * <p>Calling this method resets the wasUpdated state of all fields. So for this
+     * sequence:</p>
+     * 
+     * <pre>
+     * {@code
+     * // retrieve the current state of the issue
+     * Issue currentState = issueManager.getIssueById(12);
+     * // enable update tracking and reset list of updated properties
+     * currentState.setUpdateTracking(true);
+     * // Change state of issue
+     * currentState.setSubject("New subject");
+     * // now the change can be detected (used when updating issue)
+     * assert currentState.wasUpdated(Issue.PROP_SUBJECT);
+     * // and it is visible, that updateTracking as used
+     * assert currentState.isUpdateTracking();
+     * }
+     * </pre>
+     * 
+     * <p>It is expected, that this method is only called once the issue was
+     * retrieved by the backend.</p>
+     * 
+     * @param updateTracking new state of update tracking
+     */
+    public void setUpdateTracking(boolean updateTracking) {
+        this.updateTracking = updateTracking;
+        updated.clear();
     }
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -280,70 +280,169 @@ public class RedmineJSONBuilder {
 		JsonOutput.addIfNotNull(writer, "name", group.getName());
 	}
 
-	public static void writeIssue(Issue issue, final JSONWriter writer) throws JSONException {
-		JsonOutput.addIfNotNull(writer, "id", issue.getId());
-		JsonOutput.addIfNotNull(writer, "subject", issue.getSubject());
-		JsonOutput.addIfNotNull(writer, "parent_issue_id", issue.getParentId());
-		JsonOutput.addIfNotNull(writer, "estimated_hours",
-				issue.getEstimatedHours());
-		JsonOutput.addIfNotNull(writer, "spent_hours", issue.getSpentHours());
-		if (issue.getAssignee() != null)
-			JsonOutput.addIfNotNull(writer, "assigned_to_id", issue
-					.getAssignee().getId());
-		JsonOutput.addIfNotNull(writer, "priority_id", issue.getPriorityId());
-		JsonOutput.addIfNotNull(writer, "done_ratio", issue.getDoneRatio());
-        if (issue.getProject() != null) {
-            // Checked in Redmine 2.6.0: updating issues based on
-            // identifier fails and only using the project id works.
-            // As the identifier usage is used in several places, this
-            // case selection is introduced. The identifier is
-            // used, if no real ID is provided
-            if (issue.getProject().getId() != null) {
-                JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
-                        .getId());
-            } else {
-                JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
-                        .getIdentifier());
-            }
+        public static void writeIssue(Issue issue, final JSONWriter writer)
+                throws JSONException {
+                JsonOutput.addIfNotNull(writer, "id", issue.getId());
+                if (!issue.isUpdateTracking()) {
+                        JsonOutput.addIfNotNull(writer, "subject", issue.getSubject());
+                        JsonOutput.addIfNotNull(writer, "parent_issue_id", issue.getParentId());
+                        JsonOutput.addIfNotNull(writer, "estimated_hours", issue.getEstimatedHours());
+                        JsonOutput.addIfNotNull(writer, "spent_hours", issue.getSpentHours());
+                        if (issue.getAssignee() != null) {
+                                JsonOutput.addIfNotNull(writer, "assigned_to_id", issue
+                                        .getAssignee().getId());
+                        }
+                        JsonOutput.addIfNotNull(writer, "priority_id", issue.getPriorityId());
+                        JsonOutput.addIfNotNull(writer, "done_ratio", issue.getDoneRatio());
+                        if (issue.getProject() != null) {
+                                // Checked in Redmine 2.6.0: updating issues based on
+                                // identifier fails and only using the project id works.
+                                // As the identifier usage is used in several places, this
+                                // case selection is introduced. The identifier is
+                                // used, if no real ID is provided
+                                if (issue.getProject().getId() != null) {
+                                        JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
+                                                .getId());
+                                } else {
+                                        JsonOutput.addIfNotNull(writer, "project_id", issue.getProject()
+                                                .getIdentifier());
+                                }
+                        }
+                        if (issue.getAuthor() != null) {
+                                JsonOutput.addIfNotNull(writer, "author_id", issue.getAuthor()
+                                        .getId());
+                        }
+                        addShort2(writer, "start_date", issue.getStartDate());
+                        addIfNotNullShort2(writer, "due_date", issue.getDueDate());
+                        if (issue.getTracker() != null) {
+                                JsonOutput.addIfNotNull(writer, "tracker_id", issue.getTracker()
+                                        .getId());
+                        }
+                        JsonOutput.addIfNotNull(writer, "description", issue.getDescription());
+                        addIfNotNullFull(writer, "created_on", issue.getCreatedOn());
+                        addIfNotNullFull(writer, "updated_on", issue.getUpdatedOn());
+                        JsonOutput.addIfNotNull(writer, "status_id", issue.getStatusId());
+                        if (issue.getTargetVersion() != null) {
+                                JsonOutput.addIfNotNull(writer, "fixed_version_id", issue
+                                        .getTargetVersion().getId());
+                        }
+                        if (issue.getCategory() != null) {
+                                JsonOutput.addIfNotNull(writer, "category_id", issue.getCategory()
+                                        .getId());
+                        }
+                } else {
+                        if (issue.wasUpdated(Issue.PROP_SUBJECT)) {
+                                writer.key("subject").value(issue.getSubject());
+                        }
+                        if(issue.wasUpdated(Issue.PROP_PARENT_ID)) {
+                                writer.key("parent_issue_id").value(issue.getParentId());
+                        }
+                        if(issue.wasUpdated(Issue.PROP_ESTIMATED_HOURS)) {
+                                writer.key("estimated_hours").value(issue.getEstimatedHours());
+                        }
+                        if(issue.wasUpdated(Issue.PROP_SPENT_HOURS)) {
+                                writer.key("spent_hours").value(issue.getSpentHours());
+                        }
+                        if (issue.wasUpdated(Issue.PROP_ASSIGNEE)) {
+                                Integer assignee_id = null;
+                                if (issue.getAssignee() != null) {
+                                        assignee_id =  issue.getAssignee().getId();
+                                }
+                                writer.key("assigned_to_id").value(assignee_id);
+                        }
+                        if(issue.wasUpdated(Issue.PROP_PRIORITY_ID)) {
+                                writer.key("priority_id").value(issue.getPriorityId());
+                        }
+                        if(issue.wasUpdated(Issue.PROP_DONE_RATIO)) {
+                                writer.key("done_ratio").value(issue.getDoneRatio());
+                        }
+                        if (issue.wasUpdated(Issue.PROP_PROJECT)) {
+                                Object project_id = null;
+                                if (issue.getProject() != null) {
+                                        // Checked in Redmine 2.6.0: updating issues based on
+                                        // identifier fails and only using the project id works.
+                                        // As the identifier usage is used in several places, this
+                                        // case selection is introduced. The identifier is
+                                        // used, if no real ID is provided
+                                        if (issue.getProject().getId() != null) {
+                                                project_id = issue.getProject()
+                                                        .getId();
+                                        } else {
+                                                project_id = issue.getProject()
+                                                        .getIdentifier();
+                                        }
+                                
+                                }
+                                writer.key("project_id").value(project_id);
+                        }
+                        if(issue.wasUpdated(Issue.PROP_AUTHOR)) {
+                                Integer author_id = null;
+                                if (issue.getAuthor() != null) {
+                                        author_id = issue.getAuthor().getId();
+                                }
+                                writer.key("author_id").value(author_id);
+                        }
+                        if(issue.wasUpdated(Issue.PROP_START_DATE)) {
+                                addShort2(writer, "start_date", issue.getStartDate());
+                        }
+                        if(issue.wasUpdated(Issue.PROP_DUE_DATE)) {
+                                addShort2(writer, "due_date", issue.getDueDate());
+                        }
+                        if (issue.wasUpdated(Issue.PROP_TRACKER)) {
+                                Integer tracker_id = null;
+                                if (issue.getTracker() != null) {
+                                        tracker_id = issue.getTracker().getId();
+                                }
+                                writer.key("tracker_id").value(tracker_id);
+                        }
+                        if(issue.wasUpdated(Issue.PROP_DESCRIPTION)) {
+                                writer.key("description").value(issue.getDescription());
+                        }
+                        if(issue.wasUpdated(Issue.PROP_CREATED_ON)) {
+                                writer.key("created_on").value(issue.getCreatedOn());
+                        }
+                        if (issue.wasUpdated(Issue.PROP_UPDATED_ON)) {
+                                writer.key("updated_on").value(issue.getUpdatedOn());
+                        }
+                        if ( issue.wasUpdated(Issue.PROP_STATUS_ID)) {
+                                writer.key("status_id").value(issue.getStatusId());
+                        }
+                        if (issue.wasUpdated(Issue.PROP_TARGET_VERSION)) {
+                                Integer target_version_id = null;
+                                if (issue.getTargetVersion() != null) {
+                                        target_version_id = issue.getTargetVersion().getId();
+                                }
+                                writer.key("fixed_version_id").value(target_version_id);
+                        }
+                        if (issue.wasUpdated(Issue.PROP_CATEGORY)) {
+                                Integer category_id = null;
+                                if (issue.getCategory() != null) {
+                                        category_id = issue.getCategory().getId();
+                                }
+                                writer.key("category_id").value(category_id);
+                        }
+                }
+                JsonOutput.addIfNotNull(writer, "notes", issue.getNotes());
+                writeCustomFields(writer, issue.getCustomFields());
+                Collection<Watcher> issueWatchers = issue.getWatchers();
+                if (issueWatchers != null && !issueWatchers.isEmpty()) {
+                        writeWatchers(writer, issueWatchers);
+                }
+
+                final List<Attachment> uploads = new ArrayList<Attachment>();
+                for (Attachment attachment : issue.getAttachments()) {
+                        if (attachment.getToken() != null) {
+                                uploads.add(attachment);
+                        }
+                }
+                JsonOutput.addArrayIfNotEmpty(writer, "uploads", uploads,
+                        UPLOAD_WRITER);
+
+                /*
+                 * Journals and Relations cannot be set for an issue during creation or
+                 * updates.
+                 */
         }
-        if (issue.getAuthor() != null)
-			JsonOutput.addIfNotNull(writer, "author_id", issue.getAuthor().getId());
-		addShort2(writer, "start_date", issue.getStartDate());
-		addIfNotNullShort2(writer, "due_date", issue.getDueDate());
-		if (issue.getTracker() != null)
-			JsonOutput.addIfNotNull(writer, "tracker_id", issue.getTracker().getId());
-		JsonOutput.addIfNotNull(writer, "description", issue.getDescription());
-
-		addIfNotNullFull(writer, "created_on", issue.getCreatedOn());
-		addIfNotNullFull(writer, "updated_on", issue.getUpdatedOn());
-		JsonOutput.addIfNotNull(writer, "status_id", issue.getStatusId());
-        if (issue.getTargetVersion() != null)
-            JsonOutput.addIfNotNull(writer, "fixed_version_id", issue
-                    .getTargetVersion().getId());
-        if (issue.getCategory() != null)
-            JsonOutput.addIfNotNull(writer, "category_id", issue.getCategory().getId());
-        JsonOutput.addIfNotNull(writer, "notes", issue.getNotes());
-		writeCustomFields(writer, issue.getCustomFields());
-
-        Collection<Watcher> issueWatchers = issue.getWatchers();
-        if (issueWatchers != null && !issueWatchers.isEmpty()) {
-            writeWatchers(writer, issueWatchers);
-        }
-
-        final List<Attachment> uploads = new ArrayList<Attachment>();
-        for (Attachment attachment : issue.getAttachments()) {
-            if (attachment.getToken() != null) {
-                uploads.add(attachment);
-            }
-        }
-        JsonOutput.addArrayIfNotEmpty(writer, "uploads", uploads,
-                UPLOAD_WRITER);
-
-		/*
-		 * Journals and Relations cannot be set for an issue during creation or
-		 * updates.
-		 */
-	}
 
 	public static void writeUpload(JSONWriter writer, Attachment attachment)
 			throws JSONException {

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
@@ -194,6 +194,42 @@ public class IssueManagerTest {
         }
     }
 
+   @Test
+    public void issueClearParent() {
+        try {
+            Issue parentIssue = IssueFactory.createWithSubject("parent 1");
+            Issue newParentIssue = issueManager.createIssue(projectKey, parentIssue);
+
+            assertNotNull("Checking parent was created", newParentIssue);
+            assertNotNull("Checking ID of parent issue is not null",
+                    newParentIssue.getId());
+
+            Integer parentId = newParentIssue.getId();
+
+            Issue childIssue = IssueFactory.createWithSubject("child 1");
+            childIssue.setParentId(parentId);
+
+            Issue newChildIssue = issueManager.createIssue(projectKey, childIssue);
+
+            assertEquals("Checking parent ID of the child issue",
+                    parentId, newChildIssue.getParentId());
+
+            Issue updateIssue = IssueFactory.create(newChildIssue.getId());
+            updateIssue.setUpdateTracking(true);
+            updateIssue.setParentId(null);
+            
+            issueManager.update(updateIssue);
+            
+            newChildIssue = issueManager.getIssueById(newChildIssue.getId());
+            
+            assertNull("Checking parent ID of the child issue - it should be null now",
+                    newChildIssue.getParentId());  
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+    
     @Test
     public void testUpdateIssue() {
         try {

--- a/src/test/java/com/taskadapter/redmineapi/bean/IssueTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/IssueTest.java
@@ -1,8 +1,10 @@
 package com.taskadapter.redmineapi.bean;
 
+import java.util.Date;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.*;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
 
 public class IssueTest {
     @Test
@@ -14,5 +16,95 @@ public class IssueTest {
         issue.addCustomField(field);
         issue.addCustomField(duplicateField);
         assertThat(issue.getCustomFields().size()).isEqualTo(1);
+    }
+    
+    @Test
+    public void updateTracking() { 
+        // Make sure, alle tracked fields reflect setting them
+        Issue issue = new Issue();
+        
+        assertEquals(0, issue.updated.size());
+        
+        issue.setSubject("Demo Subject");
+        
+        assertEquals(1, issue.updated.size());
+        assertThat(!issue.wasUpdated(Issue.PROP_PROJECT));
+        
+        issue.setParentId(1);
+        
+        assertThat(issue.wasUpdated(Issue.PROP_PROJECT));
+        assertEquals(2, issue.updated.size());
+        
+        issue.setEstimatedHours(2.0f);
+        
+        assertEquals(3, issue.updated.size());
+        
+        issue.setSpentHours(1.0f);
+        
+        assertEquals(4, issue.updated.size());
+        
+        issue.setAssignee(new User(1));
+        
+        assertEquals(5, issue.updated.size());
+        
+        issue.setPriorityId(1);
+        
+        assertEquals(6, issue.updated.size());
+        
+        issue.setDoneRatio(1);
+        
+        assertEquals(7, issue.updated.size());
+        
+        issue.setProject(new Project(1));
+        
+        assertEquals(8, issue.updated.size());
+        
+        issue.setAuthor(new User(2));
+        
+        assertEquals(9, issue.updated.size());
+        
+        issue.setStartDate(new Date());
+        
+        assertEquals(10, issue.updated.size());
+        
+        issue.setDueDate(new Date());
+        
+        assertEquals(11, issue.updated.size());
+        
+        issue.setTracker(new Tracker(1));
+        
+        assertEquals(12, issue.updated.size());
+        
+        issue.setDescription("Description");
+        
+        assertEquals(13, issue.updated.size());
+        
+        issue.setCreatedOn(new Date());
+        
+        assertEquals(14, issue.updated.size());
+        
+        issue.setUpdatedOn(new Date());
+        
+        assertEquals(15, issue.updated.size());
+        assertThat(! issue.wasUpdated(Issue.PROP_STATUS_ID));
+        
+        issue.setStatusId(1);
+        
+        assertThat(issue.wasUpdated(Issue.PROP_STATUS_ID));
+        assertEquals(16, issue.updated.size());
+        
+        issue.setTargetVersion(new Version(1));
+        
+        assertEquals(17, issue.updated.size());
+        
+        issue.setCategory(new IssueCategory(1));
+        
+        // Each change should be accounted for
+        assertEquals(18, issue.updated.size());
+        
+        // After (re)setting  update tracking the list should be empty
+        issue.setUpdateTracking(true);
+        
+        assertEquals(0, issue.updated.size());
     }
 }


### PR DESCRIPTION
This is the final version of the patch to support to clearing issue fields. (fixes bugs #61 and #117). 

The idea: Don't take null as an indicator not to send an update. Instead track changes (every call to a setter is considered a change) to fields and evaluate them when building the request for the server. This allows null values for the "normal" meaning: Unset value.

The implementation allows "old school" users to continue using "their way" - new users and users wanting to fix their updating bug have to switch to "UpdateTracking". There are tests added:

1. Proofing that the tracking works (IssueTest.java)
2. Proofing that unsetting a parent issue works with API (IssueManagerTest.java)

There is more that could be done (apply this principle to other objects), but the pressure comes from the issues - and to be frank that is my main intention (I use the java api in the netbeans issue integration).