### PR TITLE
Enhance dateparsing to support full xsd:datetime/xsd:date and accommodat...

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineDateUtils.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineDateUtils.java
@@ -1,9 +1,14 @@
 package com.taskadapter.redmineapi.internal;
 
+import java.text.ParseException;
+import java.util.Date;
+import javax.xml.bind.DatatypeConverter;
+
 /**
  * Redmine date conversion utils.
  * 
  * @author maxkar
+ * @author Matthias Bläsing
  */
 public final class RedmineDateUtils {
 	/**
@@ -28,4 +33,75 @@ public final class RedmineDateUtils {
 	 */
 	public static final LocalDateFormat SHORT_DATE_FORMAT_V2 = new LocalDateFormat(
 			"yyyy-MM-dd");
+        
+        private static final LocalDateFormat[] dateTimeFormats = new LocalDateFormat[] {
+            FULL_DATE_FORMAT,
+            FULL_DATE_FORMAT_V2
+        };
+        
+        // SHORT_DATE_FORMAT_V2 is covered by DatatypeConverter
+        private static final LocalDateFormat[] dateFormats = new LocalDateFormat[] {
+            SHORT_DATE_FORMAT
+        };
+        
+        /**
+         * Try to parse supplied string as a datetime/date and return resulting
+         * date.
+         * 
+         * @param inputString
+         * @return parsed date
+         * @throws IllegalArgumentException in case of parse fail
+         * @throws NullPointerException if inputString is null
+         */
+        public static Date parseDate(String inputString) {
+            // The idea:
+            // - Try to parse supplied string as a datetime using JAXB DatatypeConverter
+            // - If that fails fall back to old datetime formats - known to be used
+            // - Try to parse supplied string as a date using JAXB DatatypeConverter
+            // - If that fails fall back to old short format
+            // If everything fails it is not a date...
+            if(inputString == null) {
+                throw new NullPointerException("Input must not be null");
+            }
+            Date result = null;
+            try {
+                result = DatatypeConverter.parseDateTime(inputString).getTime();
+            } catch (IllegalArgumentException ex) {
+                // Ok - not a valid xsd:datetime
+            }
+            if (result != null) {
+                return result;
+            }
+            for(LocalDateFormat ldf: dateTimeFormats) {
+                try {
+                    result = ldf.get().parse(inputString);
+                    break;
+                } catch (ParseException ex) {
+                    // Ok - try next
+                }
+            }
+            if(result != null) {
+                return result;
+            }
+            try {
+                result = DatatypeConverter.parseDate(inputString).getTime();
+            } catch (IllegalArgumentException ex) {
+                // Ok - not a valid xsd:date
+            }
+            if(result != null) {
+                return result;
+            }
+            for(LocalDateFormat ldf: dateFormats) {
+                try {
+                    result = ldf.get().parse(inputString);
+                    break;
+                } catch (ParseException ex) {
+                    // Ok - try next
+                }
+            }
+            if(result == null) {
+                throw new IllegalArgumentException("Failed to parse: " + inputString);
+            }
+            return result;
+        }
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -455,6 +455,7 @@ public class RedmineJSONBuilder {
 	 * @throws JSONException
 	 *             if io error occurs.
 	 */
+        @Deprecated
 	public static void addIfNotNullShort(JSONWriter writer, String field,
 			Date value) throws JSONException {
 		final SimpleDateFormat format = RedmineDateUtils.SHORT_DATE_FORMAT

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -699,26 +699,11 @@ public class RedmineJSONParser {
 	private static Date getDateOrNull(JSONObject obj, String field) throws JSONException {
 		String dateStr = JsonInput.getStringOrNull(obj, field);
 		if (dateStr == null) {
-            return null;
-        }
+                    return null;
+                }
 		try {
-			if (dateStr.length() >= 5 && dateStr.charAt(4) == '/') {
-				return RedmineDateUtils.FULL_DATE_FORMAT.get().parse(dateStr);
-			}
-			if (dateStr.endsWith("Z")) {
-				dateStr = dateStr.substring(0, dateStr.length() - 1)
-						+ "GMT-00:00";
-			} else {
-				final int inset = 6;
-				if (dateStr.length() <= inset)
-					throw new JSONException("Bad date value " + dateStr);
-				String s0 = dateStr.substring(0, dateStr.length() - inset);
-				String s1 = dateStr.substring(dateStr.length() - inset,
-						dateStr.length());
-				dateStr = s0 + "GMT" + s1;
-			}
-			return RedmineDateUtils.FULL_DATE_FORMAT_V2.get().parse(dateStr);
-		} catch (ParseException e) {
+			return RedmineDateUtils.parseDate(dateStr);
+		} catch (IllegalStateException e) {
 			throw new JSONException("Bad date value " + dateStr);
 		}
 	}
@@ -732,21 +717,15 @@ public class RedmineJSONParser {
 	 *            field to get a value from.
 	 */
 	private static Date getShortDateOrNull(JSONObject obj, String field) throws JSONException {
-        final String dateStr = JsonInput.getStringOrNull(obj, field);
-        if (dateStr == null) {
-            return null;
-        }
-        final SimpleDateFormat dateFormat; 
-        if (dateStr.length() >= 5 && dateStr.charAt(4) == '/')
-            dateFormat = RedmineDateUtils.SHORT_DATE_FORMAT.get();
-        else
-            dateFormat = RedmineDateUtils.SHORT_DATE_FORMAT_V2.get();
-
-        try {
-            return dateFormat.parse(dateStr);
-        } catch (ParseException e) {
-            throw new JSONException("Bad date " + dateStr);
-        }
+            final String dateStr = JsonInput.getStringOrNull(obj, field);
+            if (dateStr == null) {
+                return null;
+            }
+            try {
+                return RedmineDateUtils.parseDate(dateStr);
+            } catch (IllegalArgumentException e) {
+                throw new JSONException("Bad date " + dateStr);
+            }
 	}
 
 	public static JSONObject getResponseSingleObject(String body, String key) throws JSONException {

--- a/src/test/java/com/taskadapter/redmineapi/internal/RedmineDateUtilsTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/RedmineDateUtilsTest.java
@@ -1,0 +1,47 @@
+package com.taskadapter.redmineapi.internal;
+
+import java.text.ParseException;
+import static org.hamcrest.core.Is.is;
+import org.junit.Test;
+
+import org.json.JSONException;
+import org.junit.Assert;
+
+/**
+ * Redmine JSON date parser tests.
+ *
+ * @author Matthias Bläsing
+ *
+ */
+public class RedmineDateUtilsTest {
+
+    @Test
+    public void testWorkingDates() {
+        String[] datesSeenInTheWild = {
+            "2015/02/26 20:54:12Z",
+            "2015/02/26 20:54:12 +0100",
+            "2015/02/26 20:54:12 GMT+01:00",
+            "2015-02-26T20:54:12TOT",
+            "2015-02-26T20:54:12+01:00",
+            "2015/02/26+02:00",
+            "2015/02/26",
+            "2015-02-26"
+        };
+        
+        int parsed = 0;
+        for(String date: datesSeenInTheWild) {
+            try {
+                RedmineDateUtils.parseDate(date);
+                parsed++;
+            } catch (IllegalArgumentException ex) {
+            }
+        }
+        
+        Assert.assertThat(parsed, is(datesSeenInTheWild.length));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonWorkingDate() {
+        RedmineDateUtils.parseDate("2014-13-01");
+    }
+}


### PR DESCRIPTION
...e to changes in redmine 3.0.0

It looks as if redmine once again changed the dateformat. Both (old and new) are valid xsd:datetimes, the new one just contains fractional parts of seconds.

From redmine 2.6.0: `"updated_on":"2015-01-23T00:15:24Z"`
From redmine 3.0.0: `"updated_on":"2015-01-29T10:06:19.000Z"`

The fractional part is optional - while going over this I found this: http://www.redmine.org/issues/7394 and the mentioning of XML datetime is sensible. This lead me to JAXB, datetime parsing for standard format is a done job.

So I implemented a method, that tries the standard format and also supports the old non-standard formats.

See discussion here: https://github.com/redminenb/redminenb/issues/27

To be fair I'm not sure whether this is redmine 2.6 vs. redmine 3.0 or some rails difference, but I don't think it does not matter.

