### PR TITLE
Generate Javadoc and auto-push to gh-pages.

### DIFF
--- a/.buildscript/push-javadoc-to-gh-pages.sh
+++ b/.buildscript/push-javadoc-to-gh-pages.sh
@@ -12,7 +12,7 @@ cp -R build/docs/javadoc $TDIR/javadoc-latest
 cd $TDIR
 
 echo "Cloning current gh-pages branch..."
-git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/a11n/redmine-java-api gh-pages > /dev/null
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/taskadapter/redmine-java-api gh-pages > /dev/null
 
 cd gh-pages
 

--- a/.buildscript/push-javadoc-to-gh-pages.sh
+++ b/.buildscript/push-javadoc-to-gh-pages.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+echo "Deploying javadoc..."
+
+TDIR=`mktemp -d -t javadoc`
+
+echo "Creating temporary directory..."
+mkdir -v $TDIR/javadoc-latest
+
+echo "Copying files to temporary directory..."
+cp -R build/docs/javadoc $TDIR/javadoc-latest
+
+cd $TDIR
+
+echo "Cloning current gh-pages branch..."
+git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/a11n/redmine-java-api gh-pages > /dev/null
+
+cd gh-pages
+
+echo "Cleaning..."
+git rm -rf . > /dev/null
+
+echo "Copying javadocs to gh-pages..."
+cp -Rf $TDIR/javadoc-latest/javadoc/ .
+git add -f .
+git commit -m "Latest javadoc auto-pushed to gh-pages." > /dev/null
+git push -fq origin gh-pages > /dev/null
+
+echo "javadoc deployed!"
+
+echo "Removing temporary files..."
+rm -rf $TDIR > /dev/null

--- a/build.gradle
+++ b/build.gradle
@@ -114,3 +114,8 @@ artifacts {
     archives packageSources
     archives packageJavadoc
 }
+
+task generateJavadocForGhPages(type: Javadoc) {
+    source = sourceSets.main.allJava
+    exclude '**/internal/**' 
+}


### PR DESCRIPTION
As extensively discussed in #176 this PR features two enhancements:

1. Create Javadoc without package internal
2. Auto-push Javadocs to gh-pages to host them online

Justifications:
1. I created a dedicated task for the Javadoc creation. In a previous PR I just configured Javadoc to omit the package, but since Javadoc is also used in another task (packageJavadoc), configuring an own tasks does not influence the other task.
2. Since cloud CI (travis) was not desired, I wrote a shell script which runs on a local machine to fulfill auto-push

Usage:
1. Generate Javadoc first `./gradlew clean generateJavadocForGhPages` (use clean to ensure internal package has not been generated from other tasks)
2. Set & export your GH_TOKEN
```shell
> GH_TOKEN=<your token>
> export GH_TOKEN
```
3. Execute the script
```shell
> .buildscript/push-javadoc-to-gh-pages.sh 
Deploying javadoc...
Creating temporary directory...
mkdir: created directory '/var/folders/hx/4lyxw6bs0417ztrz3w92ndn80000gp/T/javadoc.C6nzwxLo/javadoc-latest'
Copying files to temporary directory...
Cloning current gh-pages branch...
Cleaning...
Copying javadocs to gh-pages...
javadoc deployed!
Removing temporary files...
```

**Remark:** I wrote and tested the script on OS X, where mktemp might have a slightly other usage than on a linux machine. It may be necessary to replace `mktemp -d -t javadoc`with just `mktemp -d`