### PR TITLE
Fixed issue upload large file

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
@@ -370,6 +370,32 @@ public final class Transport {
 		final String result = send(request);
 		return parseResponse(result, "upload", RedmineJSONParser.UPLOAD_TOKEN_PARSER);
 	}
+	
+	
+		/**
+	 * UPloads content on a server.
+	 * 
+	 * @param content
+	 *            content stream of type file.
+	 * @return uploaded item token.
+	 * @throws RedmineException
+	 *             if something goes wrong.
+	 */
+	public String upload(File content) throws RedmineException {
+
+		final URI uploadURI = getURIConfigurator().getUploadURI();
+		final HttpPost request = new HttpPost(uploadURI);
+
+		MultipartEntityBuilder mpEntity = MultipartEntityBuilder.create();
+		mpEntity.addBinaryBody("userfile", content);
+		mpEntity.seContentType(ContentType.APPLICATION_OCTET_STREAM);
+
+		HttpEntity entity = mpEntity.build();
+		request.setEntity(entity);
+
+		final String result = send(request);
+		return parseResponse(result, "upload", RedmineJSONParser.UPLOAD_TOKEN_PARSER);
+	}
 
 	/**
 	 * @param classs


### PR DESCRIPTION
I found the bug. You can't upload InputStream because big files seems to plant . You need to use a File type on your files.

I added the class upload(File content), and you need to add the last version of httpclient and httpcore (4.4) , and add httpmime to your pom.xml :
<dependency>
		<groupId>org.apache.httpcomponents</groupId>
		<artifactId>httpmime</artifactId>
		<version>4.4</version>
		</dependency>
    <dependency>

I didn't delete upload(InpuStream content) but she is useless now .