### PR TITLE
Add custom fields to the version JSON writer, add unit test

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -196,6 +196,7 @@ public class RedmineJSONBuilder {
 		addIfNotNullShort2(writer, "due_date", version.getDueDate());
 		addIfNotNullFull(writer, "created_on", version.getCreatedOn());
 		addIfNotNullFull(writer, "updated_on", version.getUpdatedOn());
+		writeCustomFields(writer, version.getCustomFields());
 	}
 
 	/**

--- a/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONGeneratorTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONGeneratorTest.java
@@ -4,6 +4,11 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import com.taskadapter.redmineapi.bean.Issue;
+import com.taskadapter.redmineapi.bean.Version;
+import com.taskadapter.redmineapi.bean.VersionFactory;
+import com.taskadapter.redmineapi.bean.CustomField;
+import com.taskadapter.redmineapi.bean.CustomFieldFactory;
+import java.util.Collections;
 
 public class RedmineJSONGeneratorTest {
 	/**
@@ -20,4 +25,17 @@ public class RedmineJSONGeneratorTest {
 		assertTrue(generatedJSON.contains("\"priority_id\":1,"));
 	}
 
+	/**
+	 * Tests whether custom fields are serialized to the JSON of a {@link Version}
+	 */
+	@Test
+	public void customFieldsAreWrittenToVersionIfProvided() {
+		Version version = VersionFactory.create(1);
+		CustomField field = CustomFieldFactory.create(2, "myName", "myValue");
+		version.addCustomFields(Collections.singletonList(field));
+
+		final String generatedJSON = RedmineJSONBuilder.toSimpleJSON(
+				"dummy", version, RedmineJSONBuilder.VERSION_WRITER);
+		assertTrue(generatedJSON.contains("\"custom_field_values\":{\"2\":\"myValue\"}"));
+	}
 }


### PR DESCRIPTION
With this fix, it is now possible to add or change custom field values on a Redmine version