### PR TITLE
Issue #212. Updated Apache HttpClient dependency to v. 4.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,7 @@ repositories {
 }
 
 dependencies {
-    compile ('org.apache.httpcomponents:httpclient:4.2',
-            'org.apache.httpcomponents:httpcore:4.2',
+    compile ('org.apache.httpcomponents:httpclient:4.5.1',
             'org.json:json:20090211',
             'org.slf4j:slf4j-api:1.7.1')
 

--- a/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
@@ -59,8 +59,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -594,7 +594,7 @@ public final class Transport {
 		StringEntity entity;
 		try {
 			entity = new StringEntity(body, CHARSET);
-		} catch (UnsupportedEncodingException e) {
+		} catch (UnsupportedCharsetException e) {
 			throw new RedmineInternalError("Required charset " + CHARSET
 					+ " is not supported", e);
 		}


### PR DESCRIPTION
also removed explicit dependency on Apache HttpCore:
that library is referenced in HttpClient's pom.xml file anyway.

fixed one place in Transport.java where they changed the API,
everything else looks fine. existing tests pass.