### PR TITLE
 Issue #227. switch from Fest-assert library to AssertJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ dependencies {
 
     testCompile(
             'junit:junit:4.12',
-            'org.easytesting:fest-assert:1.4',
+            // can't use AssertJ 3.x because it requires Java 8
+            'org.assertj:assertj-core:2.1.0',
             'org.slf4j:slf4j-jdk14:1.7.1'
     )
 }

--- a/src/test/java/com/taskadapter/redmineapi/AttachmentIntegrationTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/AttachmentIntegrationTest.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.UUID;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/src/test/java/com/taskadapter/redmineapi/CustomFieldDefinitionsTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/CustomFieldDefinitionsTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import java.util.List;
 import org.json.JSONException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * The tests expect some manual (one-time) setup in the Redmine server because

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerTest.java
@@ -47,7 +47,7 @@ import static com.taskadapter.redmineapi.IssueHelper.createIssues;
 import com.taskadapter.redmineapi.bean.CustomField;
 import java.util.Arrays;
 import java.util.Collections;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/taskadapter/redmineapi/MembershipManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/MembershipManagerTest.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MembershipManagerTest {
     private static RedmineManager mgr;

--- a/src/test/java/com/taskadapter/redmineapi/ParentProjectTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/ParentProjectTest.java
@@ -5,7 +5,7 @@ import com.taskadapter.redmineapi.bean.ProjectFactory;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParentProjectTest {
 
@@ -27,7 +27,7 @@ public class ParentProjectTest {
                 createProject(childKey, "Child Project", parentProject.getId());
 
         try {
-            assertEquals(childProject.getParentId(), parentProject.getId());
+            assertThat(childProject.getParentId()).isEqualTo(parentProject.getId());
         } finally {
             // Alexey: I verified that deleting the parent project deletes the child one as well
             // (at least on Redmine 2.3.3)

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.taskadapter.redmineapi.CustomFieldResolver.getCustomFieldByName;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/com/taskadapter/redmineapi/ProjectsTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectsTest.java
@@ -4,12 +4,13 @@ import java.util.List;
 
 import com.taskadapter.redmineapi.bean.ProjectFactory;
 import org.json.JSONObject;
-import org.junit.Assert;
 import com.taskadapter.redmineapi.bean.Project;
 import com.taskadapter.redmineapi.internal.RedmineJSONParser;
 import com.taskadapter.redmineapi.internal.json.JsonInput;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProjectsTest {
 
@@ -26,8 +27,7 @@ public class ProjectsTest {
 
     @Test
     public void testProjectsNumber() {
-        int expectedProjectsNumber = 12;
-        Assert.assertEquals("Checking projects number", expectedProjectsNumber, projectsList.size());
+        assertThat(projectsList.size()).isEqualTo(12);
     }
 
     @Test
@@ -37,12 +37,12 @@ public class ProjectsTest {
         aceProject.setName("test project 15");
 
         Project projectFromList = findProjectInList(aceProject.getId());
-        Assert.assertNotNull("Checking project is loaded", projectFromList);
+        assertThat(projectFromList).isNotNull();
 
         // could use project.equals later when it's implemented in the class
-        Assert.assertEquals("Checking the loaded project info", aceProject.getId(), projectFromList.getId());
-        Assert.assertEquals("Checking the loaded project info", aceProject.getName(), projectFromList.getName());
-        Assert.assertEquals("Checking the loaded project info", aceProject.getIdentifier(), projectFromList.getIdentifier());
+        assertThat(projectFromList.getId()).isEqualTo(aceProject.getId());
+        assertThat(projectFromList.getName()).isEqualTo(aceProject.getName());
+        assertThat(projectFromList.getIdentifier()).isEqualTo(aceProject.getIdentifier());
     }
 
     /*

--- a/src/test/java/com/taskadapter/redmineapi/RedmineManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/RedmineManagerTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for RedmineManager.

--- a/src/test/java/com/taskadapter/redmineapi/UserIntegrationTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/UserIntegrationTest.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/com/taskadapter/redmineapi/WikiManagerTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/WikiManagerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class WikiManagerTest {
 

--- a/src/test/java/com/taskadapter/redmineapi/bean/IssueTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/IssueTest.java
@@ -2,7 +2,7 @@ package com.taskadapter.redmineapi.bean;
 
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class IssueTest {
     @Test

--- a/src/test/java/com/taskadapter/redmineapi/bean/UserTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/UserTest.java
@@ -2,7 +2,7 @@ package com.taskadapter.redmineapi.bean;
 
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserTest {
     @Test

--- a/src/test/java/com/taskadapter/redmineapi/internal/RedmineDateParserTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/RedmineDateParserTest.java
@@ -6,7 +6,7 @@ import java.text.ParseException;
 import java.util.Date;
 
 import static com.taskadapter.redmineapi.internal.RedmineDateParser.parse;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RedmineDateParserTest {
     private static final LocalDateFormat FULL_DATE_FORMAT_V3 = new LocalDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSz");

--- a/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONParserTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONParserTest.java
@@ -1,6 +1,6 @@
 package com.taskadapter.redmineapi.internal;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
 AssertJ is a successor of fest-assert, which seems to be abandoned.