### PR TITLE
Allow issue/catory assignment to users and groups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'signing'
 apply plugin: 'eclipse'
 
 group = 'com.taskadapter'
-version = '2.7.0-SNAPSHOT'
+version = '3.0.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/taskadapter/redmineapi/bean/Assignee.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Assignee.java
@@ -1,0 +1,16 @@
+
+package com.taskadapter.redmineapi.bean;
+
+/**
+ * Assignee is a named representation of an assignee.
+ * 
+ * <p>An assignee is can be a user or a group. For parsing a GenericAssignee
+ * exists, that only holds a name and id (redmine only returns these infos
+ * when querying an issue.</p>
+ * 
+ * <p>All subclasses must implements equals, so that assignees are only compared
+ * based on ID.</p>
+ */
+public interface Assignee extends Identifiable {
+    String getName();
+}

--- a/src/main/java/com/taskadapter/redmineapi/bean/GenericAssignee.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/GenericAssignee.java
@@ -1,0 +1,62 @@
+
+package com.taskadapter.redmineapi.bean;
+
+import java.util.Objects;
+
+public class GenericAssignee implements Assignee {
+    private int id;
+    private String name;
+
+    GenericAssignee() {
+    }
+
+    GenericAssignee(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        if( name == null ) {
+            return String.format("Assignee ID %d", id);
+        } else {
+            return name;
+        }
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 79 * hash + this.id;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Assignee)) {
+            return false;
+        }
+        final Assignee other = (Assignee) obj;
+        
+        return Objects.equals(getId(), other.getId());
+    }
+}

--- a/src/main/java/com/taskadapter/redmineapi/bean/GenericAssigneeFactory.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/GenericAssigneeFactory.java
@@ -1,0 +1,8 @@
+
+package com.taskadapter.redmineapi.bean;
+
+public class GenericAssigneeFactory {
+    public static Assignee createGenericAssignee(int id, String name) {
+        return new GenericAssignee(id, name);
+    }
+}

--- a/src/main/java/com/taskadapter/redmineapi/bean/Group.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Group.java
@@ -1,7 +1,8 @@
 package com.taskadapter.redmineapi.bean;
 
+import java.util.Objects;
 
-public class Group implements Identifiable {
+public class Group implements Identifiable, Assignee {
 	
     private final Integer id;
     private String name;
@@ -15,10 +16,12 @@ public class Group implements Identifiable {
         this.id = id;
     }
 
+    @Override
     public Integer getId() {
         return id;
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -37,14 +40,17 @@ public class Group implements Identifiable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        
+        if (o == null || (! (o instanceof Assignee)))  {
+            return false;
+        }
 
-        Group group = (Group) o;
-
-        if (id != null ? !id.equals(group.id) : group.id != null) return false;
-
-        return true;
+        Assignee assignee = (Assignee) o;
+        
+        return Objects.equals(getId(), assignee.getId());
     }
 
     @Override

--- a/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Issue.java
@@ -27,7 +27,7 @@ public class Issue implements Identifiable {
     private Integer parentId;
     private Float estimatedHours;
     private Float spentHours;
-    private User assignee;
+    private Assignee assignee;
     private String priorityText;
     private Integer priorityId;
     private Integer doneRatio;
@@ -99,11 +99,11 @@ public class Issue implements Identifiable {
         this.priorityText = priority;
     }
 
-    public User getAssignee() {
+    public Assignee getAssignee() {
         return assignee;
     }
 
-    public void setAssignee(User assignee) {
+    public void setAssignee(Assignee assignee) {
         this.assignee = assignee;
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/bean/IssueCategory.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/IssueCategory.java
@@ -15,7 +15,7 @@ public class IssueCategory implements Identifiable, Serializable {
 
     private String name;
     private Project project;
-    private User assignee;
+    private Assignee assignee;
 
     /**
      * @param id database ID.
@@ -44,11 +44,11 @@ public class IssueCategory implements Identifiable, Serializable {
         this.project = project;
     }
 
-    public User getAssignee() {
+    public Assignee getAssignee() {
         return assignee;
     }
 
-    public void setAssignee(User assignee) {
+    public void setAssignee(Assignee assignee) {
         this.assignee = assignee;
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/bean/User.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/User.java
@@ -4,12 +4,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
  * Redmine's User.
  */
-public class User implements Identifiable {
+public class User implements Identifiable, Assignee {
 
     public static final Integer STATUS_LOCKED = 3;
 
@@ -134,16 +135,19 @@ public class User implements Identifiable {
 		this.authSourceId = authSource;
 	}
 
-	@Override
+    @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        
+        if (o == null || (! (o instanceof Assignee)))  {
+            return false;
+        }
 
-        User user = (User) o;
-
-        if (id != null ? !id.equals(user.id) : user.id != null) return false;
-
-        return true;
+        Assignee assignee = (Assignee) o;
+        
+        return Objects.equals(getId(), assignee.getId());
     }
 
     @Override
@@ -156,6 +160,11 @@ public class User implements Identifiable {
      */
     public String getFullName() {
         return firstName + " " + lastName;
+    }
+
+    @Override
+    public String getName() {
+        return getFullName();
     }
 
     // TODO add junit test

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -7,8 +7,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.taskadapter.redmineapi.bean.Assignee;
 import com.taskadapter.redmineapi.bean.AttachmentFactory;
 import com.taskadapter.redmineapi.bean.CustomFieldFactory;
+import com.taskadapter.redmineapi.bean.GenericAssigneeFactory;
 import com.taskadapter.redmineapi.bean.GroupFactory;
 import com.taskadapter.redmineapi.bean.IssueCategoryFactory;
 import com.taskadapter.redmineapi.bean.IssueFactory;
@@ -59,7 +61,6 @@ import com.taskadapter.redmineapi.bean.User;
 import com.taskadapter.redmineapi.bean.Version;
 import com.taskadapter.redmineapi.bean.Watcher;
 import com.taskadapter.redmineapi.internal.json.JsonInput;
-import com.taskadapter.redmineapi.internal.json.JsonObjectParser;
 
 /**
  * A parser for JSON items sent by Redmine.
@@ -210,7 +211,7 @@ public final class RedmineJSONParser {
 		result.setEstimatedHours(JsonInput.getFloatOrNull(content,
 				"estimated_hours"));
 		result.setSpentHours(JsonInput.getFloatOrNull(content, "spent_hours"));
-		result.setAssignee(JsonInput.getObjectOrNull(content, "assigned_to", RedmineJSONParser::parseUser));
+		result.setAssignee(JsonInput.getObjectOrNull(content, "assigned_to", RedmineJSONParser::parseAssignee));
 
 		final JSONObject priorityObject = JsonInput.getObjectOrNull(content,
 				"priority");
@@ -262,7 +263,7 @@ public final class RedmineJSONParser {
 		result.setProject(JsonInput.getObjectOrNull(content, "project",
 				RedmineJSONParser::parseMinimalProject));
 		result.setAssignee(JsonInput.getObjectOrNull(content, "assigned_to",
-				RedmineJSONParser::parseUser));
+				RedmineJSONParser::parseAssignee));
 		return result;
 	}
 
@@ -445,6 +446,18 @@ public final class RedmineJSONParser {
 		result.setName(JsonInput.getStringOrNull(content, "name"));
 		return result;
 	}
+        
+    public static Assignee parseAssignee(JSONObject content) throws JSONException {
+        // Generid assignee has to contain an id - else it can't be a returned
+        // assignee
+        final Integer id = JsonInput.getIntOrNull(content, "id");
+        if(id == null) {
+            return null;
+        } else {
+            String name = JsonInput.getStringOrNull(content, "name");
+            return GenericAssigneeFactory.createGenericAssignee(id, name);
+        }
+    }
 
     public static WikiPage parseWikiPage(JSONObject object) throws JSONException {
         WikiPage wikiPage = WikiPageFactory.create(JsonInput.getStringNotNull(object, "title"));

--- a/src/test/java/com/taskadapter/redmineapi/bean/AssigneeTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/AssigneeTest.java
@@ -1,0 +1,23 @@
+
+package com.taskadapter.redmineapi.bean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AssigneeTest {
+    @Test
+    public void testAssigneeEquivalent() {
+        Assignee demoAssignee = GenericAssigneeFactory.createGenericAssignee(1, "Demo Assignee");
+        Group group = GroupFactory.create(1);
+        group.setName("Testgroup");
+        User user = UserFactory.create(1);
+        user.setFullName("A testuser");
+        
+        assert demoAssignee.equals(group);
+        assert group.equals(demoAssignee);
+        assert demoAssignee.equals(user);
+        assert user.equals(demoAssignee);
+        assert user.equals(group);
+        assert group.equals(user);
+    }
+}

--- a/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONParserTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/RedmineJSONParserTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 import com.taskadapter.redmineapi.DateComparator;
 import com.taskadapter.redmineapi.MyIOUtils;
 import com.taskadapter.redmineapi.RedmineTestUtils;
+import com.taskadapter.redmineapi.bean.GenericAssignee;
 import com.taskadapter.redmineapi.bean.Issue;
+import com.taskadapter.redmineapi.bean.IssueCategory;
 import com.taskadapter.redmineapi.bean.IssueStatus;
 import com.taskadapter.redmineapi.bean.News;
 import com.taskadapter.redmineapi.bean.Project;
@@ -429,5 +431,39 @@ public class RedmineJSONParserTest {
 		Assert.assertEquals(expectedCustomeFieldValue, version
 			.getCustomFieldById(1).getValue());
 		Assert.assertEquals("", version.getCustomFieldById(6).getValue());
+    }
+    
+    @Test
+    public void testAssigneeParserIssue() throws IOException, JSONException {
+        String json = MyIOUtils
+			.getResourceAsString("issue/issue_with_assignee.json");
+        Issue issue = RedmineJSONParser.parseIssue(RedmineJSONParser.getResponse(json));
+        assertThat(issue.getAssignee()).isInstanceOf(GenericAssignee.class);
+        assertThat(issue.getAssignee().getId()).isEqualTo(3);
+        assertThat(issue.getAssignee().getName()).isEqualTo("Dina TheDog");
+    }
+    
+    @Test
+    public void testAssigneeParserCategories() throws IOException, JSONException {
+        String json = MyIOUtils.getResourceAsString("issue_categories.json");
+        List<IssueCategory> categories = JsonInput.getListOrEmpty(
+                                RedmineJSONParser.getResponse(json),
+				"issue_categories",
+                                RedmineJSONParser::parseCategory);
+        
+        // Basic category structure
+        assertThat(categories).hasSize(2);
+        assertThat(categories.get(0).getId()).isEqualTo(112);
+        assertThat(categories.get(0).getName()).isEqualTo("test");
+        assertThat(categories.get(1).getId()).isEqualTo(113);
+        assertThat(categories.get(1).getName()).isEqualTo("test2");
+        
+        // First category has assigne with id 1 and name "Redmine Admin"
+        assertNotNull(categories.get(0).getAssignee());
+        assertThat(categories.get(0).getAssignee().getId()).isEqualTo(1);
+        assertThat(categories.get(0).getAssignee().getName()).isEqualTo("Redmine Admin");
+        
+        // Second categorie has no assignee
+        assertNull(categories.get(1).getAssignee());
     }
 }

--- a/src/test/resources/issue/issue_with_assignee.json
+++ b/src/test/resources/issue/issue_with_assignee.json
@@ -1,0 +1,35 @@
+{
+    "id": 239,
+    "project": {
+        "name": "test",
+        "id": 1
+    },
+    "tracker": {
+        "name": "Bug",
+        "id": 1
+    },
+    "status": {
+        "name": "New",
+        "id": 1
+    },
+    "priority": {
+        "name": "High",
+        "id": 5
+    },
+    "author": {
+        "name": "Redmine Admin",
+        "id": 1
+    },
+    "assigned_to": {
+        "name": "Dina TheDog",
+        "id": 3
+    },
+    "subject": "task 239",
+    "description": "",
+    "start_date": "2011/01/12",
+    "due_date": "2011/01/30",
+    "done_ratio": 0,
+    "estimated_hours": 20.0,
+    "created_on": "2011/01/12 16:00:31 -0800",
+    "updated_on": "2011/01/17 21:28:45 -0800"
+}

--- a/src/test/resources/issue_categories.json
+++ b/src/test/resources/issue_categories.json
@@ -1,0 +1,22 @@
+{
+    "issue_categories": [{
+            "id": 112,
+            "project": {
+                "id": 2096,
+                "name": "test project"
+            },
+            "name": "test",
+            "assigned_to": {
+                "id": 1,
+                "name": "Redmine Admin"
+            }
+        }, {
+            "id": 113,
+            "project": {
+                "id": 2096,
+                "name": "test project"
+            },
+            "name": "test2"
+        }],
+    "total_count": 2
+}


### PR DESCRIPTION
- New interface Assignee implemented by User and Group
- change "assigne" attribute of Issue and IssueCategory to Assignee
- add a GenericAssignee implementing Assigne to handle return values
  that don't indicate whether a User or Group is returned

This is a transplantation of the changes against the updated master branch from the pre-JDK8 branch.

This is based on the comments in issue 213.