### PR TITLE
Results wrapper

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/IssueManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/IssueManager.java
@@ -80,12 +80,12 @@ public class IssueManager {
      </pre>
 
      * @param parameters the http parameters key/value pairs to append to the rest api request
-     * @return empty list if no issues found matching given parameters
+     * @return resultsWrapper with raw response from Redmine REST API
      * @throws RedmineAuthenticationException invalid or no API access key is used with the server, which
      *                                 requires authorization. Check the constructor arguments.
      * @throws RedmineException
      */
-    public List<Issue> getIssues(Map<String, String> parameters) throws RedmineException {
+    public ResultsWrapper<Issue> getIssues(Map<String, String> parameters) throws RedmineException {
         return DirectObjectsSearcher.getObjectsListNoPaging(transport, parameters, Issue.class);
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/TimeEntryManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/TimeEntryManager.java
@@ -3,6 +3,7 @@ package com.taskadapter.redmineapi;
 import com.taskadapter.redmineapi.bean.TimeEntry;
 import com.taskadapter.redmineapi.bean.TimeEntryActivity;
 import com.taskadapter.redmineapi.internal.DirectObjectsSearcher;
+import com.taskadapter.redmineapi.internal.ResultsWrapper;
 import com.taskadapter.redmineapi.internal.Transport;
 import org.apache.http.message.BasicNameValuePair;
 
@@ -59,12 +60,12 @@ public final class TimeEntryManager {
      * http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries#Listing-time-entries
      *
      * @param parameters the http parameters key/value pairs to append to the rest api request
-     * @return empty list if no elements found matching given parameters
+     * @return resultsWrapper with raw response from Redmine REST API
      * @throws RedmineAuthenticationException invalid or no API access key is used with the server, which
      *                                 requires authorization. Check the constructor arguments.
      * @throws RedmineException
      */
-    public List<TimeEntry> getTimeEntries(Map<String, String> parameters) throws RedmineException {
+    public ResultsWrapper<TimeEntry> getTimeEntries(Map<String, String> parameters) throws RedmineException {
         return DirectObjectsSearcher.getObjectsListNoPaging(transport, parameters, TimeEntry.class);
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/UserManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/UserManager.java
@@ -4,6 +4,7 @@ import com.taskadapter.redmineapi.bean.Group;
 import com.taskadapter.redmineapi.bean.Role;
 import com.taskadapter.redmineapi.bean.User;
 import com.taskadapter.redmineapi.internal.DirectObjectsSearcher;
+import com.taskadapter.redmineapi.internal.ResultsWrapper;
 import com.taskadapter.redmineapi.internal.Transport;
 import org.apache.http.message.BasicNameValuePair;
 
@@ -95,12 +96,12 @@ public class UserManager {
      </pre>
      *
      * @param parameters http parameters: key/value pairs to append to the rest api request
-     * @return empty list if no objects found using provided parameters
+     * @return resultsWrapper with raw response from Redmine REST API
      * @throws RedmineAuthenticationException invalid or no API access key is used with the server, which
      *                                 requires authorization. Check the constructor arguments.
      * @throws RedmineException
      */
-    public List<User> getUsers(Map<String, String> parameters) throws RedmineException {
+    public ResultsWrapper<User> getUsers(Map<String, String> parameters) throws RedmineException {
         return DirectObjectsSearcher.getObjectsListNoPaging(transport, parameters, User.class);
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/internal/DirectObjectsSearcher.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/DirectObjectsSearcher.java
@@ -10,13 +10,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class DirectObjectsSearcher {
-    public static <T> List<T> getObjectsListNoPaging(Transport transport, Map<String, String> map, Class<T> classRef) throws RedmineException {
+
+    public static <T> ResultsWrapper<T> getObjectsListNoPaging(Transport transport, Map<String, String> map, Class<T> classRef) throws RedmineException {
         final Set<NameValuePair> set = map.entrySet()
                 .stream()
                 .map(param -> new BasicNameValuePair(param.getKey(), param.getValue()))
                 .collect(Collectors.toSet());
 
-        final ResultsWrapper<T> wrapper = transport.getObjectsListNoPaging(classRef, set);
-        return wrapper.getResults();
+        return transport.getObjectsListNoPaging(classRef, set);
     }
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/ResultsWrapper.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/ResultsWrapper.java
@@ -2,17 +2,21 @@ package com.taskadapter.redmineapi.internal;
 
 import java.util.List;
 
-public class ResultsWrapper<T> {
-    final private Integer totalFoundOnServer;
-    final private List<T> results;
+public final class ResultsWrapper<T> {
+    private final Integer totalFoundOnServer;
+    private final Integer limitOnServer;
+    private final Integer offsetOnServer;
+    private final List<T> results;
 
-    public ResultsWrapper(Integer totalFoundOnServer, List<T> results) {
+    public ResultsWrapper(Integer totalFoundOnServer, Integer limitOnServer, Integer offsetOnServer, List<T> results) {
         this.totalFoundOnServer = totalFoundOnServer;
+        this.limitOnServer = limitOnServer;
+        this.offsetOnServer = offsetOnServer;
         this.results = results;
     }
 
     public boolean hasSomeResults() {
-        return !results.isEmpty();
+        return results != null && !results.isEmpty();
     }
 
     public List<T> getResults() {
@@ -20,10 +24,18 @@ public class ResultsWrapper<T> {
     }
 
     public int getResultsNumber() {
-        return results.size();
+        return results != null ? results.size() : 0;
     }
 
     public Integer getTotalFoundOnServer() {
         return totalFoundOnServer;
+    }
+
+    public Integer getLimitOnServer() {
+        return limitOnServer;
+    }
+
+    public Integer getOffsetOnServer() {
+        return offsetOnServer;
     }
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/Transport.java
@@ -74,6 +74,8 @@ public final class Transport {
 	private static final String CONTENT_TYPE = "application/json; charset=utf-8";
 	private static final int DEFAULT_OBJECTS_PER_PAGE = 25;
 	private static final String KEY_TOTAL_COUNT = "total_count";
+	private static final String KEY_LIMIT = "limit";
+	private static final String KEY_OFFSET = "offset";
 
 	private final Logger logger = LoggerFactory.getLogger(RedmineManager.class);
 	private final SimpleCommunicator<String> communicator;
@@ -489,7 +491,9 @@ public final class Transport {
 			final JSONObject responseObject = RedmineJSONParser.getResponse(response);
 			List<T> results = JsonInput.getListOrNull(responseObject, config.multiObjectName, config.parser);
 			Integer totalFoundOnServer = JsonInput.getIntOrNull(responseObject, KEY_TOTAL_COUNT);
-			return new ResultsWrapper<>(totalFoundOnServer, results);
+			Integer limitOnServer = JsonInput.getIntOrNull(responseObject, KEY_LIMIT);
+			Integer offsetOnServer = JsonInput.getIntOrNull(responseObject, KEY_OFFSET);
+			return new ResultsWrapper<>(totalFoundOnServer, limitOnServer, offsetOnServer, results);
 		} catch (JSONException e) {
 			throw new RedmineFormatException(e);
 		}

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
@@ -369,7 +369,7 @@ public class IssueManagerIT {
         params.put("limit", "3");
         params.put("offset", "0");
         params.put("project_id", projectId + "");
-        List<Issue> issues = issueManager.getIssues(params);
+        List<Issue> issues = issueManager.getIssues(params).getResults();
         // only the requested number of issues is loaded, not all result pages.
         assertThat(issues.size()).isEqualTo(3);
     }
@@ -1270,7 +1270,7 @@ public class IssueManagerIT {
             Map<String, String> params = new HashMap<>();
             params.put("project_id", Integer.toString(projectId));
             params.put("subject", "~free_form_search");
-            List<Issue> issues = issueManager.getIssues(params);
+            List<Issue> issues = issueManager.getIssues(params).getResults();
             assertThat(issues.size()).isEqualTo(1);
             final Issue loaded = issues.get(0);
             assertThat(loaded.getSubject()).isEqualTo(subject);

--- a/src/test/java/com/taskadapter/redmineapi/TimeEntryManagerIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/TimeEntryManagerIT.java
@@ -262,13 +262,13 @@ public class TimeEntryManagerIT {
             Map<String, String> paramsForActivity8 = new HashMap<>();
             paramsForActivity8.put("issue_id", Integer.toString(createdIssueId));
             paramsForActivity8.put("activity_id", ACTIVITY_ID + "");
-            List<TimeEntry> timeEntriesForActivity8 = timeEntryManager.getTimeEntries(paramsForActivity8);
+            List<TimeEntry> timeEntriesForActivity8 = timeEntryManager.getTimeEntries(paramsForActivity8).getResults();
             assertThat(timeEntriesForActivity8.size()).isEqualTo(3);
 
             Map<String, String> paramsForActivity9 = new HashMap<>();
             paramsForActivity9.put("issue_id", Integer.toString(createdIssueId));
             paramsForActivity9.put("activity_id", "9");
-            List<TimeEntry> timeEntriesForActivity9 = timeEntryManager.getTimeEntries(paramsForActivity9);
+            List<TimeEntry> timeEntriesForActivity9 = timeEntryManager.getTimeEntries(paramsForActivity9).getResults();
             assertThat(timeEntriesForActivity9.size()).isEqualTo(1);
         } finally {
             issueManager.deleteIssue(createdIssueId);

--- a/src/test/java/com/taskadapter/redmineapi/UserIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/UserIT.java
@@ -105,7 +105,7 @@ public class UserIT {
 
             Map<String, String> params = new HashMap<>();
             params.put("name", name);
-            List<User> list = userManager.getUsers(params);
+            List<User> list = userManager.getUsers(params).getResults();
             assertThat(list.size()).isEqualTo(1);
             final User loaded = list.get(0);
             assertThat(loaded.getFirstName()).isEqualTo(name);


### PR DESCRIPTION
Relates to #259 

The only thing I dislike is to keep short name for deprecated method: e.g `getTimeEntries()` vs `getTimeEntriesResultsWrapper()`. Commits like 682e8a614006753ae809455baa56f1c1d6ff3f6e simply remove old methods `getAssignee()` with new ones `getAssigneeName()` and `getAssigneeId()` but I want to ask before propose a break in compatibility.

Even more I don't know if a single commit is preferred.

I can rebase and squash after code review