### PR TITLE
Allow setting TargetVersion+Category to null / access names from Memberships

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Membership.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Membership.java
@@ -21,7 +21,12 @@ public class Membership implements Identifiable {
 	 * User. Not set for "group" membership.
 	 */
 	public final static Property<Integer> USER_ID = new Property<>(Integer.class, "userId");
+        public final static Property<String> USER_NAME = new Property<>(String.class, "userName");
+        /**
+         * Group. Not set for "user" membership.
+         */
 	public final static Property<Integer> GROUP_ID = new Property<>(Integer.class, "groupId");
+        public final static Property<String> GROUP_NAME = new Property<>(String.class, "groupName");
 	public final static Property<Set<Role>> ROLES = (Property<Set<Role>>) new Property(Set.class, "roles");
 
     /**
@@ -64,6 +69,22 @@ public class Membership implements Identifiable {
 
     public void setGroupId(Integer id) {
 		storage.set(GROUP_ID, id);
+    }
+    
+	public String getUserName() {
+		return storage.get(USER_NAME);
+	}
+
+	public void setUserName(String id) {
+		storage.set(USER_NAME, id);
+	}
+
+    public String getGroupName() {
+        return storage.get(GROUP_NAME);
+    }
+
+    public void setGroupName(String id) {
+		storage.set(GROUP_NAME, id);
     }
 
     public Collection<Role> getRoles() {

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -4,6 +4,7 @@ import com.taskadapter.redmineapi.RedmineInternalError;
 import com.taskadapter.redmineapi.bean.Attachment;
 import com.taskadapter.redmineapi.bean.CustomField;
 import com.taskadapter.redmineapi.bean.Group;
+import com.taskadapter.redmineapi.bean.Identifiable;
 import com.taskadapter.redmineapi.bean.Issue;
 import com.taskadapter.redmineapi.bean.IssueCategory;
 import com.taskadapter.redmineapi.bean.IssueRelation;
@@ -207,30 +208,21 @@ public class RedmineJSONBuilder {
 		addIfSet(writer, "spent_hours", storage, Issue.SPENT_HOURS);
 		addIfSet(writer, "assigned_to_id", storage, Issue.ASSIGNEE_ID);
 		addIfSet(writer, "priority_id", storage, Issue.PRIORITY_ID);
-        addIfSet(writer, "done_ratio", storage, Issue.DONE_RATIO);
+                addIfSet(writer, "done_ratio", storage, Issue.DONE_RATIO);
 		addIfSet(writer, "is_private", storage, Issue.PRIVATE_ISSUE);
 		addIfSet(writer, "project_id", storage, Issue.PROJECT_ID);
 		addIfSet(writer, "author_id", storage, Issue.AUTHOR_ID);
 		addIfSet(writer, "start_date", storage, Issue.START_DATE, RedmineDateParser.SHORT_DATE_FORMAT_V2.get());
 		addIfSet(writer, "due_date", storage, Issue.DUE_DATE, RedmineDateParser.SHORT_DATE_FORMAT_V2.get());
-		if (issue.getTracker() != null) {
-			writer.key("tracker_id");
-			writer.value(issue.getTracker().getId());
-		}
+                addIfSetIdentifiable(writer, "tracker_id", storage, Issue.TRACKER);
 		addIfSet(writer, "description", storage, Issue.DESCRIPTION);
 
 		addIfSetFullDate(writer, "created_on", storage, Issue.CREATED_ON);
 		addIfSetFullDate(writer, "updated_on", storage, Issue.UPDATED_ON);
 		addIfSet(writer, "status_id", storage, Issue.STATUS_ID);
-        if (issue.getTargetVersion() != null) {
-        	writer.key("fixed_version_id");
-			writer.value(issue.getTargetVersion().getId());
-		}
-        if (issue.getCategory() != null) {
-			writer.key("category_id");
-			writer.value(issue.getCategory().getId());
-		}
-        addIfSet(writer, "notes", storage, Issue.NOTES);
+                addIfSetIdentifiable(writer, "fixed_version_id", storage, Issue.TARGET_VERSION);
+                addIfSetIdentifiable(writer, "category_id", storage, Issue.ISSUE_CATEGORY);
+                addIfSet(writer, "notes", storage, Issue.NOTES);
 		writeCustomFields(writer, issue.getCustomFields());
 
         Collection<Watcher> issueWatchers = issue.getWatchers();
@@ -267,6 +259,18 @@ public class RedmineJSONBuilder {
 		final SimpleDateFormat format = RedmineDateParser.FULL_DATE_FORMAT.get();
 		addIfSet(writer, jsonKeyName, storage, property, format);
 	}
+        
+        private static void addIfSetIdentifiable(JSONWriter writer, String jsonKeyName, PropertyStorage storage, Property<? extends Identifiable> property) throws JSONException {
+                if (storage.isPropertySet(property)) {
+                        final Identifiable propertyValue = storage.get(property);
+                        writer.key(jsonKeyName);
+                        if(propertyValue != null) {
+                            writer.value(propertyValue.getId());
+                        } else {
+                            writer.value(null);
+                        }
+                } 
+        }
 
 	private static void addIfSet(JSONWriter writer, String jsonKeyName, PropertyStorage storage, Property<Date> property, SimpleDateFormat format) throws JSONException {
 		if (storage.isPropertySet(property)) {

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -443,10 +443,12 @@ public final class RedmineJSONParser {
 		final User user = JsonInput.getObjectOrNull(content, "user", RedmineJSONParser::parseUser);
 		if (user != null) {
 			result.setUserId(user.getId());
+                        result.setUserName(user.getFullName());
 		}
 		final Group group = JsonInput.getObjectOrNull(content, "group", RedmineJSONParser::parseGroup);
 		if (group != null) {
 			result.setGroupId(group.getId());
+                        result.setGroupName(group.getName());
 		}
 		result.addRoles(JsonInput.getListOrEmpty(content, "roles", RedmineJSONParser::parseRole));
 		return result;

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
@@ -759,6 +759,11 @@ public class IssueManagerIT {
         issueManager.update(createdIssue);
         Issue updatedIssue = issueManager.getIssueById(createdIssue.getId());
         assertThat(updatedIssue.getTargetVersion().getName()).isEqualTo(version2Name);
+        
+        createdIssue.setTargetVersion(null);
+        issueManager.update(createdIssue);
+        updatedIssue = issueManager.getIssueById(createdIssue.getId());
+        assertThat(updatedIssue.getTargetVersion()).isNull();
     }
 
     private Version createVersion(String versionName) throws RedmineException {
@@ -986,6 +991,11 @@ public class IssueManagerIT {
             assertEquals("Name of category retrieved for issue "
                             + newIssue.getId() + " is wrong",
                     newIssueCategory.getName(), retrievedCategory.getName());
+            
+            retrievedIssue.setCategory(null);
+            issueManager.update(retrievedIssue);
+            Issue updatedIssue = issueManager.getIssueById(newIssue.getId());
+            assertThat(updatedIssue.getCategory()).isNull();
         } finally {
             if (newIssue != null) {
                 issueManager.deleteIssue(newIssue.getId());

--- a/src/test/java/com/taskadapter/redmineapi/MembershipManagerIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/MembershipManagerIT.java
@@ -121,6 +121,34 @@ public class MembershipManagerIT {
         membershipManager.delete(membershipForUser);
     }
 
+    @Test
+    public void membershipsContainUserName() throws RedmineException {
+        final List<Role> roles = mgr.getUserManager().getRoles();
+        final User currentUser = mgr.getUserManager().getCurrentUser();
+
+        final Membership membershipForUser = membershipManager.createMembershipForUser(project.getId(), currentUser.getId(), roles);
+        final List<Membership> memberships = membershipManager.getMemberships(project.getId());
+        assertThat(memberships.get(0).getUserName()).isEqualTo(currentUser.getFullName());
+        membershipManager.delete(membershipForUser);
+    }
+    
+    @Test
+    public void membershipsContainGoupName() throws RedmineException {
+        final List<Role> roles = mgr.getUserManager().getRoles();
+        final Group group = GroupFactory.create("group" + new Random().nextDouble());
+        Group createdGroup = null;
+        try {
+            createdGroup = mgr.getUserManager().createGroup(group);
+
+            Membership newMembership = membershipManager
+                    .createMembershipForGroup(project.getId(), createdGroup.getId(), roles);
+            List<Membership> memberships = membershipManager.getMemberships(project.getIdentifier());
+            assertThat(memberships.get(0).getGroupName()).isEqualTo(createdGroup.getName());
+        } finally {
+            mgr.getUserManager().deleteGroup(createdGroup);
+        }
+    }
+    
     private void verifyMemberships(List<Role> roles, User currentUser, List<Membership> memberships) throws RedmineException {
         assertThat(memberships.size()).isEqualTo(1);
         final Membership membership = memberships.get(0);


### PR DESCRIPTION
This is the result of moving redminenb to the new major version of redmine-java-api.

Most changes are very smooth and work quite good. These two changesets address two issues:

- Memberships are used to enumerate Users per project in redminenb, so I used the Memberships directly in the past, as these already contain the necessary data (the id and name of the group/user). In the current incarnation this information is discarded by the bindings. With this changeset the names of the groups and users are extracted from the reply
- The two attributes category and and targetVersion could not be unset - the null value was discarded from the updateset. This is attributed in the second changeset by introducing a generic setter for "Identifiable" attribute values.

Please note: The first change was tested by the added unittests, the second set is currently untested, as the testsystem is unresponsive. I ran the second set through manual tests, that showed these change to be working.

Please check if the added unittests for the second part work as expected. Thanks!