### PR TITLE
Allow writing our own custom requests

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/RedmineManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/RedmineManager.java
@@ -118,4 +118,7 @@ public class RedmineManager {
         transport.setOnBehalfOfUser(loginName);
     }
 
+    public Transport getTransport() {
+        return transport;
+    }
 }


### PR DESCRIPTION
In order to allow writing our own custom requests (in the case the API has been improved by custom development), why not exporting the Transport?

We could then write our own requests like this:

```java
RedmineManager redmineManager = RedmineManagerFactory.createWithApiKey(..., ...);
Transport transport = redmineManager.getTransport();
transport.getObject(..., ...);
```