### PR TITLE
Wiki attachments

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/WikiPageDetail.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/WikiPageDetail.java
@@ -9,7 +9,7 @@ public class WikiPageDetail extends WikiPage {
     public final static Property<String> TEXT = new Property<>(String.class, "text");
     public final static Property<User> USER = new Property<>(User.class, "user");
     public final static Property<String> COMMENTS = new Property<>(String.class, "comments");
-    public final static Property<List<Attachment>> ATTACHMENTS = (Property<List<Attachment>>) new Property(List.class, "attachments");
+    public final static Property<List<Attachment>> ATTACHMENTS = (Property<List<Attachment>>) new Property(List.class, "uploads");
 
     public WikiPageDetail() {
         super();

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -346,5 +346,6 @@ public class RedmineJSONBuilder {
 		addIfSet(writer, "text", storage, WikiPageDetail.TEXT);
 		addIfSet(writer, "comments", storage, WikiPageDetail.COMMENTS);
 		addIfSet(writer, "version", storage, WikiPage.VERSION);
+		JsonOutput.addArrayIfNotEmpty(writer, "uploads", detail.getAttachments(), RedmineJSONBuilder::writeUpload);
 	}
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -496,7 +496,7 @@ public final class RedmineJSONParser {
         wikiPage.setCreatedOn(getDateOrNull(object, "created_on"));
         wikiPage.setUpdatedOn(getDateOrNull(object, "updated_on"));
 		wikiPage.setComments(JsonInput.getStringOrEmpty(object, "comments"));
-        wikiPage.setAttachments(JsonInput.getListOrNull(object, "attachments", RedmineJSONParser::parseAttachments));
+        wikiPage.setAttachments(JsonInput.getListOrNull(object, "uploads", RedmineJSONParser::parseAttachments));
 
         return wikiPage;
     }

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -496,7 +496,7 @@ public final class RedmineJSONParser {
         wikiPage.setCreatedOn(getDateOrNull(object, "created_on"));
         wikiPage.setUpdatedOn(getDateOrNull(object, "updated_on"));
 		wikiPage.setComments(JsonInput.getStringOrEmpty(object, "comments"));
-        wikiPage.setAttachments(JsonInput.getListOrNull(object, "uploads", RedmineJSONParser::parseAttachments));
+        wikiPage.setAttachments(JsonInput.getListOrNull(object, "attachments", RedmineJSONParser::parseAttachments));
 
         return wikiPage;
     }

--- a/src/test/java/com/taskadapter/redmineapi/bean/AttachmentsTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/bean/AttachmentsTest.java
@@ -1,0 +1,32 @@
+package com.taskadapter.redmineapi.bean;
+
+import com.taskadapter.redmineapi.internal.RedmineJSONBuilder;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class AttachmentsTest {
+
+    @Test
+    public void wikiPageDetailWrite() {
+        Attachment attachment1 = new Attachment(1);
+        attachment1.setToken("TOKEN1");
+        attachment1.setContentType("text/plain");
+        Attachment attachment2 = new Attachment(2);
+        attachment2.setToken("TOKEN2");
+        attachment2.setContentType("text/plain");
+        List<Attachment> attachments = Arrays.asList(attachment1, attachment2);
+
+        WikiPageDetail wikiPageDetail = new WikiPageDetail();
+        wikiPageDetail.setText("text");
+        wikiPageDetail.setAttachments(attachments);
+
+        final String generatedJSON = RedmineJSONBuilder.toSimpleJSON("some_project_key", wikiPageDetail, RedmineJSONBuilder::writeWikiPageDetail);
+        assertThat(generatedJSON).contains("\"text\":\"text\"");
+        assertThat(generatedJSON).contains("\"uploads\":[{\"token\":\"TOKEN1\",\"content_type\":\"text/plain\"},{\"token\":\"TOKEN2\",\"content_type\":\"text/plain\"}]}}");
+    }
+
+}


### PR DESCRIPTION
Continue from issue #314 
Problem was not only in renaming json key.
Attachments were never sent. `RedmineJSONBuilder` didn't have any attachments processing.

Added test for JSON object check. Also tested on the real redmine