### PR TITLE
Add getter for project status

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -44,6 +44,7 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * This is the *database ID*, not a String-based key.
      */
     public final static Property<Integer> PARENT_DATABASE_ID = new Property<>(Integer.class, "parentId");
+    public final static Property<Integer> STATUS = new Property<>(Integer.class, "status");
     public final static Property<Boolean> PUBLIC = new Property<>(Boolean.class, "public");
     public final static Property<Boolean> INHERIT_MEMBERS = new Property<>(Boolean.class, "inheritMembers");
     public final static Property<Set<CustomField>> CUSTOM_FIELDS = (Property<Set<CustomField>>) new Property(Set.class, "customFields");
@@ -52,7 +53,17 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * Trackers available for this project
      */
     public final static Property<Set<Tracker>> TRACKERS = (Property<Set<Tracker>>) new Property(Set.class, "trackers");
+<<<<<<< Upstream, based on master
     private Transport transport;
+=======
+    
+    /**
+     * Project status values, as defined in http://www.redmine.org/projects/redmine/repository/entry/trunk/app/models/project.rb
+     */
+    public static final Integer STATUS_ACTIVE = 1;
+    public static final Integer STATUS_CLOSED = 5;
+    public static final Integer STATUS_ARCHIVED= 9;
+>>>>>>> b4ed298 Add getter for project status
 
     public Project(Transport transport) {
         this.transport = transport;
@@ -186,6 +197,32 @@ public class Project implements Identifiable, Serializable, FluentStyle {
     public Project setParentId(Integer parentId) {
         storage.set(PARENT_DATABASE_ID, parentId);
         return this;
+    }
+
+    /**
+     * Returns the project status. This number can theoretically be different for different Redmine versions,
+     * But the **current Redmine version in 2018** defines these numbers as:
+     * <ul>
+     *   <li>1: status active</li>
+     *   <li>5: status closed</li>
+     *   <li>9: status archived</li>
+     * </ul>
+     * 
+     * <p>see http://www.redmine.org/projects/redmine/repository/entry/trunk/app/models/project.rb
+     *
+     * @return possibly Redmine-version-specific number that represents project status (active/closed/archived)
+     * @since Redmine REST API 2.5.0
+     */
+    public Integer getStatus() {
+    	return storage.get(STATUS);
+    }
+    /**
+     * Sets the project status (Note that this will not take effect when updating a project as
+     * the **current Redmine version in 2018** does not allow reopen, close or archive projects,
+     * see https://www.redmine.org/issues/13725)
+     */
+    public void setStatus(Integer status) {
+    	storage.set(STATUS, status);
     }
 
     /**

--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -53,17 +53,7 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * Trackers available for this project
      */
     public final static Property<Set<Tracker>> TRACKERS = (Property<Set<Tracker>>) new Property(Set.class, "trackers");
-<<<<<<< Upstream, based on master
     private Transport transport;
-=======
-    
-    /**
-     * Project status values, as defined in http://www.redmine.org/projects/redmine/repository/entry/trunk/app/models/project.rb
-     */
-    public static final Integer STATUS_ACTIVE = 1;
-    public static final Integer STATUS_CLOSED = 5;
-    public static final Integer STATUS_ARCHIVED= 9;
->>>>>>> b4ed298 Add getter for project status
 
     public Project(Transport transport) {
         this.transport = transport;

--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -221,8 +221,9 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * the **current Redmine version in 2018** does not allow reopen, close or archive projects,
      * see https://www.redmine.org/issues/13725)
      */
-    public void setStatus(Integer status) {
+    public Project setStatus(Integer status) {
     	storage.set(STATUS, status);
+    	return this;
     }
 
     /**

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -162,6 +162,7 @@ public class RedmineJSONBuilder {
 		addIfSetFullDate(writer, "updated_on", storage, Project.UPDATED_ON);
 		writeCustomFields(writer, project.getCustomFields());
 		addIfSet(writer, "parent_id", storage, Project.PARENT_DATABASE_ID);
+		addIfSet(writer, "status", storage, Project.STATUS);
 		addIfSet(writer, "is_public", storage, Project.PUBLIC);
 		addIfSet(writer, "inherit_members", storage, Project.INHERIT_MEMBERS);
 		JsonOutput.addArrayIfNotNull(writer, "trackers", project.getTrackers(), RedmineJSONBuilder::writeTracker);

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -164,6 +164,7 @@ public final class RedmineJSONParser {
 				"parent");
 		if (parentProject != null)
 			result.setParentId(JsonInput.getInt(parentProject, "id"));
+		result.setStatus(JsonInput.getIntOrNull(content, "status"));
 		result.addTrackers(JsonInput.getListOrEmpty(content, "trackers", RedmineJSONParser::parseTracker));
         result.addCustomFields(JsonInput.getListOrEmpty(content, "custom_fields", RedmineJSONParser::parseCustomField));
 		return result;

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
@@ -105,6 +105,7 @@ public class ProjectIntegrationIT {
 
     @Test
     public void testCreateProject() throws RedmineException {
+    	final Integer statusActive = 1;
         Project projectToCreate = generateRandomProject();
         String key = null;
         try {
@@ -123,7 +124,7 @@ public class ProjectIntegrationIT {
                     createdProject.getDescription());
             assertEquals(projectToCreate.getHomepage(),
                     createdProject.getHomepage());
-            assertEquals(Project.STATUS_ACTIVE, 
+            assertEquals(statusActive, 
             		createdProject.getStatus());
 
             Collection<Tracker> trackers = createdProject.getTrackers();
@@ -140,6 +141,8 @@ public class ProjectIntegrationIT {
 
     @Test
     public void testCreateGetUpdateDeleteProject() throws RedmineException {
+    	final Integer statusActive = 1;
+    	final Integer statusClosed = 5;
         Project projectToCreate = generateRandomProject();
         Project createdProject = null;
         try {
@@ -148,16 +151,10 @@ public class ProjectIntegrationIT {
             String newDescr = "NEW123";
             String newName = "new name here";
 
-<<<<<<< Upstream, based on master
             createdProject.setName(newName)
                     .setDescription(newDescr)
+                    .setStatus(statusClosed)
                     .update();
-=======
-            createdProject.setName(newName);
-            createdProject.setDescription(newDescr);
-            createdProject.setStatus(Project.STATUS_CLOSED);
-            projectManager.update(createdProject);
->>>>>>> b4ed298 Add getter for project status
 
             Project updatedProject = projectManager.getProjectByKey(createdProject.getIdentifier());
             assertNotNull(updatedProject);
@@ -167,7 +164,7 @@ public class ProjectIntegrationIT {
             assertEquals(newName, updatedProject.getName());
             assertEquals(newDescr, updatedProject.getDescription());
             //status should not change to closed as currently redmine api does not allow reopen/close/archive projects
-            assertEquals(Project.STATUS_ACTIVE, updatedProject.getStatus());
+            assertEquals(statusActive, updatedProject.getStatus());
             Collection<Tracker> trackers = updatedProject.getTrackers();
             assertNotNull("checking that project has some trackers",
                     trackers);

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
@@ -123,6 +123,8 @@ public class ProjectIntegrationIT {
                     createdProject.getDescription());
             assertEquals(projectToCreate.getHomepage(),
                     createdProject.getHomepage());
+            assertEquals(Project.STATUS_ACTIVE, 
+            		createdProject.getStatus());
 
             Collection<Tracker> trackers = createdProject.getTrackers();
             assertNotNull("checking that project has some trackers",
@@ -146,9 +148,16 @@ public class ProjectIntegrationIT {
             String newDescr = "NEW123";
             String newName = "new name here";
 
+<<<<<<< Upstream, based on master
             createdProject.setName(newName)
                     .setDescription(newDescr)
                     .update();
+=======
+            createdProject.setName(newName);
+            createdProject.setDescription(newDescr);
+            createdProject.setStatus(Project.STATUS_CLOSED);
+            projectManager.update(createdProject);
+>>>>>>> b4ed298 Add getter for project status
 
             Project updatedProject = projectManager.getProjectByKey(createdProject.getIdentifier());
             assertNotNull(updatedProject);
@@ -157,6 +166,8 @@ public class ProjectIntegrationIT {
                     updatedProject.getIdentifier());
             assertEquals(newName, updatedProject.getName());
             assertEquals(newDescr, updatedProject.getDescription());
+            //status should not change to closed as currently redmine api does not allow reopen/close/archive projects
+            assertEquals(Project.STATUS_ACTIVE, updatedProject.getStatus());
             Collection<Tracker> trackers = updatedProject.getTrackers();
             assertNotNull("checking that project has some trackers",
                     trackers);


### PR DESCRIPTION
There is a related PR #308, that is too old and not merged yet. This PR allows obtaining the STAUS of a project. There are no new tests, instead the status check is added to existing tests.

Note1: Redmine api does not allow reopen, close or archive projects. So as, Project.setStatus has only effect on the project bean, but it does not change the status in the redmine database. An issue was been recorded about this (documented in the code).

Note 2: But we still need setStatus as RedmineJSONParser needs it. A solution to avoid creating this setter could be use storage.set instead result.setStatus, but it is not possible as storage.set is not visible from RedmineJSONParser