### PR TITLE
Update project trackers on redmine server

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -130,7 +130,7 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      */
     public Project addTrackers(Collection<Tracker> trackers) {
     	if (!storage.isPropertySet(TRACKERS)) //checks because trackers storage is not created for new projects
-    		this.clearTrackers();
+    		storage.set(TRACKERS, new HashSet<>());
         storage.get(TRACKERS).addAll(trackers);
         return this;
     }
@@ -293,6 +293,12 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * 	  .create();
      * }
      * </pre>
+     * <p> 
+     * Note: if {@code project} trackers have not been set with {@link Project#addTrackers} 
+     * and if they have been cleared with {@link Project#clearTrackers},
+     * the created project will get the server default trackers (if any).
+     * Otherwise, the {@code Project} trackers will override the server default settings. 
+     * </p>
      *
      * @return the newly created Project object.
      * @throws RedmineAuthenticationException invalid or no API access key is used with the server, which

--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -57,7 +57,6 @@ public class Project implements Identifiable, Serializable, FluentStyle {
     public Project(Transport transport) {
         this.transport = transport;
         storage.set(CUSTOM_FIELDS, new HashSet<>());
-        storage.set(TRACKERS, new HashSet<>());
     }
 
     public Project(Transport transport, String name, String key) {
@@ -119,11 +118,27 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * @return Trackers allowed in this project (e.g.: Bug, Feature, Support, Task, ...)
      */
     public Collection<Tracker> getTrackers() {
+    	if (!storage.isPropertySet(TRACKERS)) //checks because trackers storage is not created for new projects
+    		return new HashSet<>();
         return Collections.unmodifiableCollection(storage.get(TRACKERS));
     }
 
+    /**
+     * Adds the specified trackers to this project.
+     * If this project is created or updated on the redmine server, 
+     * each tracker id must be a valid tracker on the server.
+     */
     public void addTrackers(Collection<Tracker> trackers) {
+    	if (!storage.isPropertySet(TRACKERS)) //checks because trackers storage is not created for new projects
+    		this.clearTrackers();
         storage.get(TRACKERS).addAll(trackers);
+    }
+
+    /**
+     * Removes all of the trackers from this project.
+     */
+    public void clearTrackers() {
+    	storage.set(TRACKERS, new HashSet<>());
     }
 
     public Tracker getTrackerByName(String trackerName) {

--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -119,7 +119,7 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      */
     public Collection<Tracker> getTrackers() {
     	if (!storage.isPropertySet(TRACKERS)) //checks because trackers storage is not created for new projects
-    		return new HashSet<>();
+    		return Collections.unmodifiableCollection(new HashSet<Tracker>());
         return Collections.unmodifiableCollection(storage.get(TRACKERS));
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/bean/Project.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Project.java
@@ -128,17 +128,19 @@ public class Project implements Identifiable, Serializable, FluentStyle {
      * If this project is created or updated on the redmine server, 
      * each tracker id must be a valid tracker on the server.
      */
-    public void addTrackers(Collection<Tracker> trackers) {
+    public Project addTrackers(Collection<Tracker> trackers) {
     	if (!storage.isPropertySet(TRACKERS)) //checks because trackers storage is not created for new projects
     		this.clearTrackers();
         storage.get(TRACKERS).addAll(trackers);
+        return this;
     }
 
     /**
      * Removes all of the trackers from this project.
      */
-    public void clearTrackers() {
+    public Project clearTrackers() {
     	storage.set(TRACKERS, new HashSet<>());
+    	return this;
     }
 
     public Tracker getTrackerByName(String trackerName) {

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -27,6 +27,7 @@ import org.json.JSONWriter;
 
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -76,24 +77,6 @@ public class RedmineJSONBuilder {
 		addIfSetFullDate(writer, "created_on", storage, TimeEntry.SPENT_ON);
 		addIfSetFullDate(writer, "updated_on", storage, TimeEntry.SPENT_ON);
 		writeCustomFields(writer, timeEntry.getCustomFields());
-	}
-
-	/**
-	 * Writes a tracker.
-	 * 
-	 * @param writer
-	 *            used writer.
-	 * @param tracker
-	 *            tracker to writer.
-	 * @throws JSONException
-	 *             if error occurs.
-	 */
-	static void writeTracker(JSONWriter writer, Tracker tracker)
-			throws JSONException {
-		writer.key("id");
-		writer.value(tracker.getId());
-		writer.key("name");
-		writer.value(tracker.getName());
 	}
 
 	static void writeRelation(JSONWriter writer, IssueRelation relation)
@@ -164,7 +147,21 @@ public class RedmineJSONBuilder {
 		addIfSet(writer, "parent_id", storage, Project.PARENT_DATABASE_ID);
 		addIfSet(writer, "is_public", storage, Project.PUBLIC);
 		addIfSet(writer, "inherit_members", storage, Project.INHERIT_MEMBERS);
-		JsonOutput.addArrayIfNotNull(writer, "trackers", project.getTrackers(), RedmineJSONBuilder::writeTracker);
+		writeProjectTrackers(writer, project);
+	}
+	private static void writeProjectTrackers(JSONWriter writer, Project project) throws JSONException {
+		//skip if storage is not already set to allow new projects get the redmine system default trackers
+		PropertyStorage storage = project.getStorage();
+		if (storage.isPropertySet(Project.TRACKERS)) {
+			Collection<Integer> trackerIds=new ArrayList<>();
+			for (Tracker tracker : project.getTrackers())
+				trackerIds.add(tracker.getId());
+			JsonOutput.addScalarArray(writer, "tracker_ids", trackerIds, RedmineJSONBuilder::writeScalarValue);			
+		}
+	}
+
+	static void writeScalarValue(JSONWriter writer, Object object) throws JSONException {
+		writer.value(object);
 	}
 
 	public static void writeCategory(final JSONWriter writer, IssueCategory category) throws JSONException {

--- a/src/main/java/com/taskadapter/redmineapi/internal/json/JsonOutput.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/json/JsonOutput.java
@@ -160,7 +160,7 @@ public class JsonOutput {
 	}
 
 	/**
-	 * Adds a list.
+	 * Adds a list of scalar values.
 	 * 
 	 * @param writer
 	 *            used writer.
@@ -169,18 +169,21 @@ public class JsonOutput {
 	 * @param items
 	 *            used items.
 	 * @param objWriter
-	 *            single object writer.
+	 *            single value writer.
 	 */
-	public static <T> void addArrayIfNotNull(JSONWriter writer, String field,
+	public static <T> void addScalarArray(JSONWriter writer, String field,
 			Collection<T> items, JsonObjectWriter<T> objWriter)
 			throws JSONException {
-		if (items == null)
-			return;
-		addCollection(writer, field, items, objWriter);
+		writer.key(field);
+		writer.array();
+		for (T item : items) {
+			objWriter.write(writer, item);
+		}
+		writer.endArray();
 	}
 
 	/**
-	 * Adds a list.
+	 * Adds a list of objects.
 	 * 
 	 * @param writer
 	 *            used writer.

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
@@ -5,7 +5,6 @@ import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
 import com.taskadapter.redmineapi.bean.CustomFieldFactory;
 import com.taskadapter.redmineapi.bean.Project;
 import com.taskadapter.redmineapi.bean.Tracker;
-import com.taskadapter.redmineapi.bean.TrackerFactory;
 import com.taskadapter.redmineapi.bean.Version;
 import com.taskadapter.redmineapi.internal.Transport;
 import org.junit.AfterClass;
@@ -213,7 +212,7 @@ public class ProjectIntegrationIT {
         Project projectToCreate = generateRandomProject();
         assertEquals(0, projectToCreate.getTrackers().size());
         
-        Collection<Tracker> trackers=new HashSet<>(Arrays.asList(TrackerFactory.create(1,"Bug")));
+        Collection<Tracker> trackers=new HashSet<>(Arrays.asList(new Tracker().setId(1).setName("Bug")));
         projectToCreate.addTrackers(trackers);
         assertEquals(1, projectToCreate.getTrackers().size());
         
@@ -266,7 +265,7 @@ public class ProjectIntegrationIT {
     @Test(expected = NotFoundException.class)
     public void testUpdateTrackersInvalidGivesException() throws RedmineException {
         int nonExistingTrackerId = 99999999;
-        Collection<Tracker> trackers=new HashSet<>(Arrays.asList(TrackerFactory.create(nonExistingTrackerId,"NonExisting")));
+        Collection<Tracker> trackers=new HashSet<>(Arrays.asList(new Tracker().setId(nonExistingTrackerId).setName("NonExisting")));
         Project projectToCreate = generateRandomProject();
         projectToCreate.addTrackers(trackers);
         projectManager.createProject(projectToCreate);

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
@@ -231,33 +231,29 @@ public class ProjectIntegrationIT {
         try {
             //project created with default trackers has been tested by testCreateProject
             //test override of default trackers on project creation
-            projectToCreate.clearTrackers();
-            Project createdProject = projectManager.createProject(projectToCreate);
+            Project createdProject = projectToCreate.clearTrackers().create();
             createdProjectKey = createdProject.getIdentifier();
             assertEquals(0, createdProject.getTrackers().size());
            
             //add single tracker
-            Collection<Tracker> trackers=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(0)));
-            createdProject.addTrackers(trackers);
-            projectManager.update(createdProject);
+            Collection<Tracker> trackersToSet=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(0)));
+            createdProject.addTrackers(trackersToSet).update();
             createdProject=projectManager.getProjectByKey(createdProjectKey);
             assertEquals(1, createdProject.getTrackers().size());
 
             //add more than one tracker, it does not replace previous trackers
             Collection<Tracker> trackersToAdd=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(1), availableTrackers.get(2)));
-            createdProject.addTrackers(trackersToAdd);
-            projectManager.update(createdProject);
+            createdProject.addTrackers(trackersToAdd).update();
             createdProject=projectManager.getProjectByKey(createdProjectKey);
             assertEquals(3, createdProject.getTrackers().size());
             
             //all trackers can be removed
-            createdProject.clearTrackers();
-            projectManager.update(createdProject);
+            createdProject.clearTrackers().update();
             createdProject=projectManager.getProjectByKey(createdProjectKey);
             assertEquals(0, createdProject.getTrackers().size());
         } finally {
             if (createdProjectKey != null) {
-                projectManager.deleteProject(createdProjectKey);
+            	projectManager.getProjectByKey(createdProjectKey).delete();
             }
         }
     }
@@ -268,7 +264,7 @@ public class ProjectIntegrationIT {
         Collection<Tracker> trackers=new HashSet<>(Arrays.asList(new Tracker().setId(nonExistingTrackerId).setName("NonExisting")));
         Project projectToCreate = generateRandomProject();
         projectToCreate.addTrackers(trackers);
-        projectManager.createProject(projectToCreate);
+        projectToCreate.create();
     }
 
     @Test

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
@@ -5,6 +5,7 @@ import com.taskadapter.redmineapi.bean.CustomFieldDefinition;
 import com.taskadapter.redmineapi.bean.CustomFieldFactory;
 import com.taskadapter.redmineapi.bean.Project;
 import com.taskadapter.redmineapi.bean.Tracker;
+import com.taskadapter.redmineapi.bean.TrackerFactory;
 import com.taskadapter.redmineapi.bean.Version;
 import com.taskadapter.redmineapi.internal.Transport;
 import org.junit.AfterClass;
@@ -17,6 +18,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -205,12 +207,71 @@ public class ProjectIntegrationIT {
         }
     }
 
-    // Redmine ignores this parameter for "get projects" request. see bug
-    // http://www.redmine.org/issues/8545
-    // The field is already accessible for a specific project for a long time (GET /projects/:id)
-    // but in the projects list (GET /projects) it's only on the svn trunk for now (Sep 8, 2014).
-    // It will be included in Redmine 2.6.0 which isn't out yet.
-    @Ignore
+    @Test
+    public void testUpdateTrackersBeforeRedmineUpdate() throws RedmineException {
+        //Trackers are undefined for new project beans, updating trackers on the project object should be allowed
+        Project projectToCreate = generateRandomProject();
+        assertEquals(0, projectToCreate.getTrackers().size());
+        
+        Collection<Tracker> trackers=new HashSet<>(Arrays.asList(TrackerFactory.create(1,"Bug")));
+        projectToCreate.addTrackers(trackers);
+        assertEquals(1, projectToCreate.getTrackers().size());
+        
+        projectToCreate.clearTrackers();
+        assertEquals(0, projectToCreate.getTrackers().size());
+    }
+    
+    @Test
+    public void testUpdateTrackersAfterRedimineUpdate() throws RedmineException {
+        //Prerequisite: verify that redmine server has at least 3 trackers (e.g. default configuration)
+        List<Tracker> availableTrackers=mgr.getIssueManager().getTrackers();
+        assertTrue("a minumum of 3 trackers should be configured in redmine", availableTrackers.size()>=3);
+
+        Project projectToCreate = generateRandomProject();
+        String createdProjectKey = null;
+        try {
+            //project created with default trackers has been tested by testCreateProject
+            //test override of default trackers on project creation
+            projectToCreate.clearTrackers();
+            Project createdProject = projectManager.createProject(projectToCreate);
+            createdProjectKey = createdProject.getIdentifier();
+            assertEquals(0, createdProject.getTrackers().size());
+           
+            //add single tracker
+            Collection<Tracker> trackers=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(0)));
+            createdProject.addTrackers(trackers);
+            projectManager.update(createdProject);
+            createdProject=projectManager.getProjectByKey(createdProjectKey);
+            assertEquals(1, createdProject.getTrackers().size());
+
+            //add more than one tracker, it does not replace previous trackers
+            trackers=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(1), availableTrackers.get(2)));
+            createdProject.addTrackers(trackers);
+            projectManager.update(createdProject);
+            createdProject=projectManager.getProjectByKey(createdProjectKey);
+            assertEquals(3, createdProject.getTrackers().size());
+            
+            //all trackers can be removed
+            createdProject.clearTrackers();
+            projectManager.update(createdProject);
+            createdProject=projectManager.getProjectByKey(createdProjectKey);
+            assertEquals(0, createdProject.getTrackers().size());
+        } finally {
+            if (createdProjectKey != null) {
+                projectManager.deleteProject(createdProjectKey);
+            }
+        }
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testUpdateTrackersInvalidGivesException() throws RedmineException {
+        int nonExistingTrackerId = 99999999;
+        Collection<Tracker> trackers=new HashSet<>(Arrays.asList(TrackerFactory.create(nonExistingTrackerId,"NonExisting")));
+        Project projectToCreate = generateRandomProject();
+        projectToCreate.addTrackers(trackers);
+        projectManager.createProject(projectToCreate);
+    }
+
     @Test
     public void testGetProjectsIncludesTrackers() throws RedmineException {
         List<Project> projects = projectManager.getProjects();

--- a/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/ProjectIntegrationIT.java
@@ -244,8 +244,8 @@ public class ProjectIntegrationIT {
             assertEquals(1, createdProject.getTrackers().size());
 
             //add more than one tracker, it does not replace previous trackers
-            trackers=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(1), availableTrackers.get(2)));
-            createdProject.addTrackers(trackers);
+            Collection<Tracker> trackersToAdd=new HashSet<Tracker>(Arrays.asList(availableTrackers.get(1), availableTrackers.get(2)));
+            createdProject.addTrackers(trackersToAdd);
             projectManager.update(createdProject);
             createdProject=projectManager.getProjectByKey(createdProjectKey);
             assertEquals(3, createdProject.getTrackers().size());


### PR DESCRIPTION
Fixes #318.

Cause: Trackers are not updated in the server because RedmineJSONBuilder.writeProject sends a collection of Tracker objects to redmine server. However the api requires an array of tracker ids.

Solution: Writing trackers uses JsonOutput.addScalarArray wich replaces JsonOutput.addArrayIfNotNull.

But this still does not solve the problem, as in the case of a new project, an empty array of trackers would be sent to the server. Therefore any default tracker configured in the server would be overridden, and the project be created without trackers.

To avoid this, now the Project constructor does not initialize the storage for TRACKERS (initializations are made in project’s getters and setters that manage trackers). An additional method to clear all trackers has been added.