### PR TITLE
changed org.json:json dependency: version 20090211 -> 20190722

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 
 dependencies {
     compile ('org.apache.httpcomponents:httpclient:4.5.6',
-            'org.json:json:20090211',
+            'org.json:json:20190722',
             'org.slf4j:slf4j-api:1.7.25')
 
     testCompile(


### PR DESCRIPTION
Hi, the current version of the library conflicts with the new version that is installed in the transitive library, we had to update the version.