### PR TITLE
Remove distinct

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
@@ -98,7 +98,8 @@ public class URIConfigurator {
      */
     private URI createURI(String query,
                           Collection<? extends RequestParam> origParams) {
-        Collection<? extends NameValuePair> nameValueParams = toNameValue(origParams);
+        Collection<? extends RequestParam> distinctParams = distinct(origParams);
+        Collection<? extends NameValuePair> nameValueParams = toNameValue(distinctParams);
         try {
             final URIBuilder builder = new URIBuilder(baseURL.toURI());
             builder.addParameters(new ArrayList<>(nameValueParams));
@@ -113,6 +114,14 @@ public class URIConfigurator {
         } catch (URISyntaxException e) {
             throw new RedmineInternalError(e);
         }
+    }
+
+    static Collection<? extends RequestParam> distinct(Collection<? extends RequestParam> origParams) {
+        return origParams
+                .stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(RequestParam::getValue, a -> a, (s1, s2) -> s1))
+                .values();
     }
 
     static Collection<? extends NameValuePair> toNameValue(Collection<? extends RequestParam> origParams) {

--- a/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
@@ -98,8 +98,7 @@ public class URIConfigurator {
      */
     private URI createURI(String query,
                           Collection<? extends RequestParam> origParams) {
-        Collection<? extends RequestParam> distinctParams = distinct(origParams);
-        Collection<? extends NameValuePair> nameValueParams = toNameValue(distinctParams);
+        Collection<? extends NameValuePair> nameValueParams = toNameValue(origParams);
         try {
             final URIBuilder builder = new URIBuilder(baseURL.toURI());
             builder.addParameters(new ArrayList<>(nameValueParams));
@@ -114,14 +113,6 @@ public class URIConfigurator {
         } catch (URISyntaxException e) {
             throw new RedmineInternalError(e);
         }
-    }
-
-    static Collection<? extends RequestParam> distinct(Collection<? extends RequestParam> origParams) {
-        return origParams
-                .stream()
-                .filter(Objects::nonNull)
-                .collect(Collectors.toMap(RequestParam::getName, a -> a, (s1, s2) -> s1))
-                .values();
     }
 
     static Collection<? extends NameValuePair> toNameValue(Collection<? extends RequestParam> origParams) {

--- a/src/test/java/com/taskadapter/redmineapi/internal/URIConfiguratorTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/URIConfiguratorTest.java
@@ -28,9 +28,9 @@ public class URIConfiguratorTest {
     }
 
     @Test
-    public void testDistinctWithSimilarNames() {
+    public void testDistinctWithSimilarNamesButDifferentValues() {
         List<RequestParam> params = Arrays.asList(param2, param2WithDifferentValue);
-        assertThat(URIConfigurator.distinct(params)).containsOnly(param2);
+        assertThat(URIConfigurator.distinct(params)).containsOnly(param2, param2WithDifferentValue);
     }
 
     @Test


### PR DESCRIPTION
Removed distinct method to maintain multiple attribute handling when filtering by params.
See: https://github.com/taskadapter/redmine-java-api/issues/339