### PR TITLE
#338 move API access key from URIs to http headers

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/RedmineManagerFactory.java
+++ b/src/main/java/com/taskadapter/redmineapi/RedmineManagerFactory.java
@@ -54,7 +54,7 @@ import java.util.List;
  * @see RedmineManager
  */
 public final class RedmineManagerFactory {
-    private static final String AUTHENTICATOR_CHARSET = "UTF-8";
+    private static final String DEFAULT_USER_PASSWORD_AUTHENTICATOR_CHARSET = "UTF-8";
 
     /**
      * Prevent construction of this object even with use of dirty tricks.
@@ -142,7 +142,11 @@ public final class RedmineManagerFactory {
     }
 
     /**
-     * Creates a new redmine managen with user-based authentication.
+     * Creates a new redmine manager with user-based authentication.
+     *
+     * This method will use UTF-8 when converting login plus password into Base64-encoded blob.
+     * Please use another "create" method in this class if you want to use some other encoding.
+     * although... why would you? please save the world and use UTF-8 encoding where possible.
      *
      * @param uri      redmine manager URI.
      * @param login    user's name.
@@ -155,7 +159,29 @@ public final class RedmineManagerFactory {
         Communicator<HttpResponse> baseCommunicator = new BaseCommunicator(httpClient);
 
         RedmineUserPasswordAuthenticator<HttpResponse> passwordAuthenticator = new RedmineUserPasswordAuthenticator<>(
-                baseCommunicator, AUTHENTICATOR_CHARSET, login, password);
+                baseCommunicator, DEFAULT_USER_PASSWORD_AUTHENTICATOR_CHARSET, login, password);
+        Transport transport = new Transport(
+                new URIConfigurator(uri), httpClient, passwordAuthenticator);
+        return new RedmineManager(transport);
+    }
+
+    /**
+     * Creates a new redmine manager with user-based authentication.
+     *
+     * @param uri      redmine manager URI.
+     * @param authenticationCharset charset to use when converting login and password to Base64-encoded string
+     * @param login    user's name.
+     * @param password user's password.
+     * @param httpClient you can provide your own pre-configured HttpClient if you want
+     *                     to control connection pooling, manage connections eviction, closing, etc.
+     */
+    public static RedmineManager createWithUserAuth(String uri, String authenticationCharset,
+                                                    String login,
+                                                    String password, HttpClient httpClient) {
+        Communicator<HttpResponse> baseCommunicator = new BaseCommunicator(httpClient);
+
+        RedmineUserPasswordAuthenticator<HttpResponse> passwordAuthenticator = new RedmineUserPasswordAuthenticator<>(
+                baseCommunicator, authenticationCharset, login, password);
         Transport transport = new Transport(
                 new URIConfigurator(uri), httpClient, passwordAuthenticator);
         return new RedmineManager(transport);

--- a/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
@@ -99,11 +99,8 @@ public class URIConfigurator {
         Collection<? extends NameValuePair> nameValueParams = toNameValue(distinctParams);
         try {
             final URIBuilder builder = new URIBuilder(baseURL.toURI());
-            builder.addParameters(new ArrayList<>(nameValueParams));
             //extra List creation needed because addParameters doesn't accept Collection<? extends NameValuePair>
-//            if (apiAccessKey != null) {
-//                builder.addParameter("key", apiAccessKey);
-//            }
+            builder.addParameters(new ArrayList<>(nameValueParams));
             if (!query.isEmpty()) {
                 builder.setPath((builder.getPath() == null? "" : builder.getPath()) + "/" + query);
             }

--- a/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/URIConfigurator.java
@@ -69,19 +69,16 @@ public class URIConfigurator {
     }
 
     private final URL baseURL;
-    private final String apiAccessKey;
 
-    public URIConfigurator(String host, String apiAccessKey) {
+    public URIConfigurator(String host) {
         if (host == null || host.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "The host parameter is NULL or empty");
+            throw new IllegalArgumentException("The host parameter is NULL or empty");
         }
         try {
             this.baseURL = new URL(host);
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Illegal host URL " + host, e);
         }
-        this.apiAccessKey = apiAccessKey;
     }
 
     public URI createURI(String query) {
@@ -104,9 +101,9 @@ public class URIConfigurator {
             final URIBuilder builder = new URIBuilder(baseURL.toURI());
             builder.addParameters(new ArrayList<>(nameValueParams));
             //extra List creation needed because addParameters doesn't accept Collection<? extends NameValuePair>
-            if (apiAccessKey != null) {
-                builder.addParameter("key", apiAccessKey);
-            }
+//            if (apiAccessKey != null) {
+//                builder.addParameter("key", apiAccessKey);
+//            }
             if (!query.isEmpty()) {
                 builder.setPath((builder.getPath() == null? "" : builder.getPath()) + "/" + query);
             }
@@ -179,23 +176,5 @@ public class URIConfigurator {
 
     public URI getUploadURI() {
         return createURI("uploads" + URL_POSTFIX);
-    }
-
-    /**
-     * Adds API key to URI, if the key is specified
-     *
-     * @param uri Original URI string
-     * @return URI with API key added
-     */
-    public URI addAPIKey(String uri) {
-        try {
-            final URIBuilder builder = new URIBuilder(uri);
-            if (apiAccessKey != null) {
-                builder.setParameter("key", apiAccessKey);
-            }
-            return builder.build();
-        } catch (URISyntaxException e) {
-            throw new RedmineInternalError(e);
-        }
     }
 }

--- a/src/main/java/com/taskadapter/redmineapi/internal/comm/redmine/RedmineApiKeyAuthenticator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/comm/redmine/RedmineApiKeyAuthenticator.java
@@ -1,0 +1,31 @@
+package com.taskadapter.redmineapi.internal.comm.redmine;
+
+import com.taskadapter.redmineapi.RedmineException;
+import com.taskadapter.redmineapi.internal.comm.Communicator;
+import com.taskadapter.redmineapi.internal.comm.ContentHandler;
+import org.apache.http.HttpRequest;
+
+public class RedmineApiKeyAuthenticator<K> implements Communicator<K> {
+
+    private final String apiKey;
+
+    /**
+     * Peer communicator.
+     */
+    private final Communicator<K> peer;
+
+    public RedmineApiKeyAuthenticator(Communicator<K> peer, String apiKey) {
+        if (apiKey == null) {
+            throw new IllegalArgumentException("api key cannot be null");
+        }
+        this.peer = peer;
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public <R> R sendRequest(HttpRequest request, ContentHandler<K, R> handler)
+            throws RedmineException {
+        request.addHeader("X-Redmine-API-Key", apiKey);
+        return peer.sendRequest(request, handler);
+    }
+}

--- a/src/main/java/com/taskadapter/redmineapi/internal/comm/redmine/RedmineUserPasswordAuthenticator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/comm/redmine/RedmineUserPasswordAuthenticator.java
@@ -1,0 +1,56 @@
+package com.taskadapter.redmineapi.internal.comm.redmine;
+
+import com.taskadapter.redmineapi.RedmineException;
+import com.taskadapter.redmineapi.RedmineInternalError;
+import com.taskadapter.redmineapi.internal.comm.Communicator;
+import com.taskadapter.redmineapi.internal.comm.ContentHandler;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpRequest;
+
+import java.io.UnsupportedEncodingException;
+
+public class RedmineUserPasswordAuthenticator<K> implements Communicator<K> {
+	/**
+	 * Header value.
+	 */
+	private String authKey;
+
+	/**
+	 * Used charset.
+	 */
+	private final String charset;
+
+	/**
+	 * Peer communicator.
+	 */
+	private final Communicator<K> peer;
+
+	public RedmineUserPasswordAuthenticator(Communicator<K> peer, String charset, String login, String password) {
+		this.peer = peer;
+		this.charset = charset;
+		setCredentials(login, password);
+	}
+
+	public void setCredentials(String login, String password) {
+		if (login == null) {
+			authKey = null;
+			return;
+		}
+		try {
+			authKey = "Basic "
+					+ Base64.encodeBase64String(
+							(login + ':' + password).getBytes(charset)).trim();
+		} catch (UnsupportedEncodingException e) {
+			throw new RedmineInternalError(e);
+		}
+	}
+
+	@Override
+	public <R> R sendRequest(HttpRequest request, ContentHandler<K, R> handler)
+			throws RedmineException {
+		if (authKey != null)
+			request.addHeader("Authorization", authKey);
+		return peer.sendRequest(request, handler);
+	}
+
+}

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
@@ -69,7 +69,7 @@ public class IssueManagerIT {
 
     @BeforeClass
     public static void oneTimeSetup() throws RedmineException {
-        mgr = IntegrationTestHelper.createRedmineManager();
+        mgr = IntegrationTestHelper.createRedmineManagerWithAPIKey();
         transport = mgr.getTransport();
         userManager = mgr.getUserManager();
         issueManager = mgr.getIssueManager();


### PR DESCRIPTION
this change moves API access key from URIs (which can be logged,
thus violating security rules) to http request headers.