### PR TITLE
Return null to caller for 204 http no response case

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/internal/comm/BaseCommunicator.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/comm/BaseCommunicator.java
@@ -43,6 +43,12 @@ public class BaseCommunicator implements Communicator<HttpResponse> {
 		try {
 			final HttpResponse httpResponse = httpclient
 					.execute((HttpUriRequest) request);
+
+			if ((httpResponse.getEntity() == null) &&
+				(httpResponse.getStatusLine().getStatusCode() == 204)) {
+				 return null;
+			}
+
 			try {
 				return handler.processContent(httpResponse);
 			} finally {


### PR DESCRIPTION
Curent HttpResponse handler assumes HttpResponse entity is not null. But for 204 no response case, it raises exception.
I got the problem with Gerrit integration with Redmine 4.1.1, where Gerrit its-redmine plugin submits three times when exception happens. When this change, there's no exception raised by redmine-java-api.