### PR TITLE
fix diacritic encoding for downloading wiki details

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/WikiManager.java
+++ b/src/main/java/com/taskadapter/redmineapi/WikiManager.java
@@ -55,8 +55,7 @@ public class WikiManager {
      * @since Redmine 2.2
      */
     public WikiPageDetail getWikiPageDetailByProjectAndTitle(String projectKey, String pageTitle) throws RedmineException {
-        String urlSafeString = WikiPageDetail.getUrlSafeString(pageTitle);
-        WikiPageDetail wikiPageDetail = transport.getChildEntry(Project.class, projectKey, WikiPageDetail.class, urlSafeString, new RequestParam("include", "attachments"));
+        WikiPageDetail wikiPageDetail = transport.getChildEntry(Project.class, projectKey, WikiPageDetail.class, pageTitle, new RequestParam("include", "attachments"));
         // Redmine REST API does not provide projectKey in response, so...
         wikiPageDetail.setProjectKey(projectKey);
         return wikiPageDetail;


### PR DESCRIPTION
Wiki pages with diacritics in their titles (lika ä,ö,ü) are not working with the current version of the client.

I suggest removing the seemingly unnessecary URL-encoding.