### PR TITLE
support Redmine 4 "delete object" empty responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# NEXT
+* support Redmine 4 "delete object" responses. Redmine 4 returns an empty response for at least some "Delete" calls,
+and the library did not know how to handle those. I added null entity handling in TransportDecoder.
+
+### known issue with Redmine 4.x: 
+Redmine 4.x REST API has a backward incompatible change in "create issue relation" API. it no longer accepts
+issue_to_id numeric parameter. it requires a comma-separated string instead. this is not yet supported in redmine-java-api. 
+
 # 4.0.0.rc3
 * added support for downloading files (#358)
 * fixed a bug in Transport class constructor: the provided client was not used

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'signing'
 apply plugin: 'eclipse'
 
 group = 'com.taskadapter'
-version = '4.0.0.rc3'
+version = '4.0.0.rc4-SNAPSHOT'
 
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/src/main/java/com/taskadapter/redmineapi/internal/comm/TransportDecoder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/comm/TransportDecoder.java
@@ -2,6 +2,7 @@ package com.taskadapter.redmineapi.internal.comm;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -20,14 +21,19 @@ final class TransportDecoder implements
 		ContentHandler<HttpResponse, BasicHttpResponse> {
 
 	@Override
-	public BasicHttpResponse processContent(HttpResponse content)
+	public BasicHttpResponse processContent(HttpResponse response)
 			throws RedmineException {
-		final HttpEntity entity = content.getEntity();
+		final HttpEntity entity = response.getEntity();
+		if (entity == null) {
+			return new BasicHttpResponse(response.getStatusLine().getStatusCode(),
+					InputStream.nullInputStream(),
+					StandardCharsets.UTF_8.name());
+		}
 		final String charset = HttpUtil.getCharset(entity);
 		final String encoding = HttpUtil.getEntityEncoding(entity);
 		try {
 			final InputStream initialStream = entity.getContent();
-			return new BasicHttpResponse(content.getStatusLine()
+			return new BasicHttpResponse(response.getStatusLine()
 					.getStatusCode(), decodeStream(encoding, initialStream),
 					charset);
 		} catch (IOException e) {

--- a/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
+++ b/src/test/java/com/taskadapter/redmineapi/IssueManagerIT.java
@@ -153,7 +153,7 @@ public class IssueManagerIT {
         assertEquals(due.get(Calendar.DAY_OF_MONTH), returnedDueCal.get(Calendar.DAY_OF_MONTH));
 
         // check ASSIGNEE
-        assertThat(ourUser.getId()).isEqualTo(newIssue.getAssigneeId());
+        assertThat(newIssue.getAssigneeId()).isEqualTo(ourUser.getId());
 
         // check AUTHOR
         Integer EXPECTED_AUTHOR_ID = IntegrationTestHelper.getOurUser(transport).getId();

--- a/src/test/resources/api_test.properties
+++ b/src/test/resources/api_test.properties
@@ -1,10 +1,15 @@
 user=user
 password=1234ZXCV
-createissue.userid=5
 userFName=Redmine
 userLName=Admin
 
 # Redmine 3.4.5
 uri=http://dev.taskadapter.com:8094
 apikey=87073b5fca478cbbac0107a4b5c518f1d8d21fa7
+createissue.userid=5
+
+# Redmine 4.2.0
+#uri=http://dev.taskadapter.com:8097
+#apikey=a45555c09a016a782a25b4e2baae96d6d2b4cf3b
+#createissue.userid=1
 


### PR DESCRIPTION
Redmine 4 returns an empty response for at least some "Delete" calls,
and the library did not know how to handle those. I added null entity handling in TransportDecoder.