### PR TITLE
support Redmine 4 new "issue relation" format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 * support Redmine 4 "delete object" responses. Redmine 4 returns an empty response for at least some "Delete" calls,
 and the library did not know how to handle those. I added null entity handling in TransportDecoder.
 
-### known issue with Redmine 4.x: 
-Redmine 4.x REST API has a backward incompatible change in "create issue relation" API. it no longer accepts
-issue_to_id numeric parameter. it requires a comma-separated string instead. this is not yet supported in redmine-java-api. 
+* support Redmine 4 new "issue relation" format.
+Redmine 4 has a backward incompatible change in its Issue Relations REST API: it now requires "issue_to_id" parameter
+to be a comma-separated string when creating issue relations (instead of previous single number).
+this change adds support for the new format. I tested this with both Redmine 3.4.5 and 4.2.0.
 
 # 4.0.0.rc3
 * added support for downloading files (#358)

--- a/src/main/java/com/taskadapter/redmineapi/bean/IssueRelation.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/IssueRelation.java
@@ -3,6 +3,9 @@ package com.taskadapter.redmineapi.bean;
 import com.taskadapter.redmineapi.RedmineException;
 import com.taskadapter.redmineapi.internal.Transport;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class IssueRelation implements Identifiable, FluentStyle {
     private Transport transport;
 
@@ -31,18 +34,25 @@ public class IssueRelation implements Identifiable, FluentStyle {
      */
     public final static Property<Integer> DATABASE_ID = new Property<>(Integer.class, "id");
     public final static Property<Integer> ISSUE_ID = new Property<>(Integer.class, "issueId");
-    public final static Property<Integer> ISSUE_TO_ID = new Property<>(Integer.class, "issueToId");
+    public final static Property<List<Integer>> ISSUE_TO_ID = new Property(List.class, "issueToId");
+
     public final static Property<String> RELATION_TYPE = new Property<>(String.class, "relationType");
     public final static Property<Integer> DELAY = new Property<>(Integer.class, "delay");
 
+    private IssueRelation() {
+        storage.set(ISSUE_TO_ID, new ArrayList<>());
+    }
+
     public IssueRelation(Transport transport) {
+        this();
         setTransport(transport);
     }
 
     public IssueRelation(Transport transport, Integer issueId, Integer issueToId, String type) {
+        this();
         setTransport(transport);
         setIssueId(issueId);
-        setIssueToId(issueToId);
+        addIssueToId(issueToId);
         setType(type);
     }
 
@@ -66,11 +76,13 @@ public class IssueRelation implements Identifiable, FluentStyle {
     }
 
     public Integer getIssueToId() {
-        return storage.get(ISSUE_TO_ID);
+        return storage.get(ISSUE_TO_ID)
+                .stream()
+                .findFirst().orElse(null);
     }
 
-    public IssueRelation setIssueToId(Integer issueToId) {
-        storage.set(ISSUE_TO_ID, issueToId);
+    public IssueRelation addIssueToId(Integer issueToId) {
+        storage.get(ISSUE_TO_ID).add(issueToId);
         return this;
     }
 

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONBuilder.java
@@ -82,9 +82,21 @@ public class RedmineJSONBuilder {
 	static void writeRelation(JSONWriter writer, IssueRelation relation)
 			throws JSONException {
 		PropertyStorage storage = relation.getStorage();
-		addIfSet(writer, "issue_to_id", storage, IssueRelation.ISSUE_TO_ID);
+		if (storage.get(IssueRelation.ISSUE_TO_ID).isEmpty()) {
+			throw new IllegalArgumentException("cannot create a relation object with no target issues defined.");
+		}
+
 		addIfSet(writer, "relation_type", storage, IssueRelation.RELATION_TYPE);
 		addIfSet(writer, "delay", storage, IssueRelation.DELAY);
+
+		// custom mapping for "issue_to_id" field
+		writer.key("issue_to_id");
+		// convert number to string to support Redmine 4.x REST API, which brought a backward incompatible change
+		// in the way issue_to_id works.
+		var value = storage.get(IssueRelation.ISSUE_TO_ID).stream()
+				.map(number -> number+"")
+				.collect(Collectors.joining(","));
+		writer.value(value);
 	}
 
 	static void writeVersion(JSONWriter writer, Version version)

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -279,7 +279,7 @@ public final class RedmineJSONParser {
 			throws JSONException {
 		final IssueRelation result = new IssueRelation(null).setId(JsonInput.getIntOrNull(content, "id"));
 		result.setIssueId(JsonInput.getIntOrNull(content, "issue_id"));
-		result.setIssueToId(JsonInput.getIntOrNull(content, "issue_to_id"));
+		result.addIssueToId(JsonInput.getIntOrNull(content, "issue_to_id"));
 		result.setType(JsonInput.getStringOrNull(content, "relation_type"));
 		result.setDelay(JsonInput.getInt(content, "delay", 0));
 		return result;


### PR DESCRIPTION
Redmine 4 has a backward incompatible change in its Issue Relations REST API: it now requires "issue_to_id" parameter
to be a comma-separated string when creating issue relations (instead of previous single number).
this change adds support for the new format. I tested this with both Redmine 3.4.5 and 4.2.0.