### PR TITLE
Multiple param patch

### DIFF
--- a/src/test/java/com/taskadapter/redmineapi/internal/URIConfiguratorTest.java
+++ b/src/test/java/com/taskadapter/redmineapi/internal/URIConfiguratorTest.java
@@ -14,6 +14,8 @@ public class URIConfiguratorTest {
     private static final RequestParam param1 = new RequestParam("name1", "value1");
     private static final RequestParam param2 = new RequestParam("name3", "value3");
     private static final RequestParam param2WithDifferentValue = new RequestParam("name3", "anotherValue3");
+    private static final RequestParam arrayParam1 = new RequestParam("name4[]", "value4");
+    private static final RequestParam arrayParam1WithDifferentValue = new RequestParam("name4[]", "anotherValue4");
     private static final RequestParam nullParam = null;
 
     @Test
@@ -42,6 +44,24 @@ public class URIConfiguratorTest {
         )).containsOnlyElementsOf(
                 params("one", "value",
                         "two", "value"));
+    }
+
+    @Test
+    public void dedupRemovesDuplicates() {
+        List<RequestParam> params = Arrays.asList(param2, param2WithDifferentValue);
+        assertThat(URIConfigurator.dedup(params)).containsOnly(param2);
+    }
+
+    @Test
+    public void dedupDoesNotRemoveArrays() {
+        List<RequestParam> params = Arrays.asList(arrayParam1, arrayParam1WithDifferentValue);
+        assertThat(URIConfigurator.dedup(params)).containsAll(params);
+    }
+
+    @Test
+    public void dedupWithDifferentNamesSameValuesShouldKeepAllItems() {
+        List<RequestParam> params = Arrays.asList(param1, param2, arrayParam1);
+        assertThat(URIConfigurator.dedup(params)).containsAll(params);
     }
 
     @Test


### PR DESCRIPTION
Suggested fix for issues #360 and #339.
This preserves duplicate request params with names ending in `[]` (which are needed if the request has multiple free-form Redmine queries), while still removing other duplicates.
(I'm not sure why duplicates are a problem in the first place, but presumably there was some reason for their removal…)

I've added unit tests for the new `dedup()` function; all the existing URIConfigurator tests still pass, too.  I wasn't able to run most of the other unit tests, as they connect to `http://dev.taskadapter.com:8097` which isn't reachable, and I don't know of an alternative test server.  But these changes are localised and shouldn't affect anything else. 
 Also, I've tested this in our own application, and confirmed that it fixes the multiple-queries issue, and doesn't seem to break anything else.