### PR TITLE
Fix: #toString() missing in Tracker.java 

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Tracker.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Tracker.java
@@ -50,4 +50,12 @@ public class Tracker implements Identifiable, Serializable {
     public int hashCode() {
         return id != null ? id.hashCode() : 0;
     }
+
+    @Override
+    public String toString() {
+        return "Tracker{" +
+               "id=" + id +
+               ", name='" + name + '\'' +
+               '}';
+    }
 }


### PR DESCRIPTION
Good Evening,

`com.taskadapter.redmineapi.bean.Tracker` seems to be the only applicable class from the bean package, to miss out on a `toString()` method.

This PR adds a `toString()`to the mentioned class.