### PR TITLE
Add private notes flag to journals

### DIFF
--- a/src/main/java/com/taskadapter/redmineapi/bean/Journal.java
+++ b/src/main/java/com/taskadapter/redmineapi/bean/Journal.java
@@ -20,6 +20,7 @@ public class Journal {
     public final static Property<String> NOTES = new Property<String>(String.class, "notes");
     public final static Property<User> USER = new Property<>(User.class, "user");
     public final static Property<Date> CREATED_ON = new Property<>(Date.class, "createdOn");
+    public final static Property<Boolean> PRIVATE_NOTES = new Property<>(Boolean.class, "privateNotes");
     public final static Property<List<JournalDetail>> DETAILS = (Property<List<JournalDetail>>) new Property(List.class, "details");
 
     public Journal() {
@@ -68,6 +69,14 @@ public class Journal {
 
     public void addDetails(Collection<JournalDetail> details) {
         storage.get(DETAILS).addAll(details);
+    }
+    
+    public Boolean isPrivateNotes() {
+        return storage.get(PRIVATE_NOTES);
+    }
+    
+    public void setIsPrivateNotes(Boolean isPrivate) {
+        storage.set(PRIVATE_NOTES, isPrivate);
     }
 
     @Override

--- a/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
+++ b/src/main/java/com/taskadapter/redmineapi/internal/RedmineJSONParser.java
@@ -332,6 +332,7 @@ public final class RedmineJSONParser {
 		result.setCreatedOn(getDateOrNull(content, "created_on"));
 		result.setNotes(JsonInput.getStringOrNull(content, "notes"));
 		result.setUser(JsonInput.getObjectOrNull(content, "user", RedmineJSONParser::parseUser));
+		result.setIsPrivateNotes(JsonInput.getOptionalBool(content, "private_notes"));
 		result.addDetails(JsonInput.getListOrEmpty(content, "details", RedmineJSONParser::parseJournalDetail));
 		return result;
 	}


### PR DESCRIPTION
com.taskadapter.redmineapi.bean.Journal class is lacking the private_notes flag that marks a note as private or not. 
This PR adds this flag as well as change the com.taskadapter.redmineapi.internal.RedmineJSONParser.parseJournal to parse the private_notes flag.